### PR TITLE
Add cursor pagination example

### DIFF
--- a/guidelines/GUIDELINES.md
+++ b/guidelines/GUIDELINES.md
@@ -278,16 +278,104 @@ All new API's shall adhere to the principles of REST (http://www.ics.uci.edu/~fi
 - `DELETE members/steve` - remove the member Steve from the collection
 
 ### Pagination
+
+APIs at Nexmo shall use one of the following pagination schemes:
+
+* Cursor based for ever-expanding data sets, or where it's infeasible to count
+the total number of records e.g. Voice API call log. Cursor based
+pagination is also used when data is programatically added to a data set e.g.
+call recordings to the Media API
+* Page based for small, managed APIs where the customer is in control of what
+is in the data set e.g. Number pools
+
+To the customer, having two different pagination methods is OK, as in practice
+they should request the first page and then follow the `_links.next` URL to get
+the next page.
+
+Cursor implementation can be decided by the engineering team. Results returned
+must be consistently ordered, and the customer can decide if the data set
+is returned in ascending or descending order.
+
+#### Cursor based
+
+Nexmo APIs shall use a cursor as their pagination option unless otherwise
+agreed with DevRel.
+
+> Cursors, if you’re not familiar, are like pointers. Pointers point at things,
+they reference a specific iota, a place in the list where your last request left
+off. A bookmark with breadcrumbs built in. (via [Slack](https://api.slack.com/docs/pagination#cursors))
+
 - There shall be a way to page through collections without additional filters.
 - There shall be a way to page through collections with filters.
+- Cursors shall not expire
 - Paging shall use a standard set of hal+json `_links`
   - `self` (current page, required)
   - `next` (next page, optional)
   - `prev` (previous page, optional)
   - `first` (first page, required)
   - `last` (last page, required)
-- Paging `_links` will include filters.
+- Paging `_links` must include filters.
+- The page size parameter must be called `page_size`
+- The cursor parameter must be called `cursor`
 
+```json
+{
+  "page_size": 100,
+  "cursor": "19284743",
+  "_embedded": [
+    {"data": "here"}
+  ],
+  "_links": {
+    "self": {
+      "href": "https://example.com/resource?page_size=100&order=asc&cursor=19284743"
+    },
+    "next": {
+      "href": "https://example.com/resource?page_size=100&order=asc&cursor=19291731"
+    },
+    "prev": {
+      "href": "https://example.com/resource?page_size=100&order=asc&cursor=19283018"
+    }
+  }
+}
+```
+
+#### Page based
+
+In certain situations (e.g. purchasing a number) it may be beneficial to skip
+over pages if you're not interested in that data. In this situation, `page` and
+`page_size` shall be used.
+
+To add a new page-based public API, you must get agreement from DevRel.
+
+- Paging shall use a standard set of hal+json `_links`
+  - `self` (current page, required)
+  - `next` (next page, optional)
+  - `prev` (previous page, optional)
+  - `first` (first page, required)
+  - `last` (last page, required)
+- Paging `_links` must include filters.
+- The page size parameter must be called `page_size`
+- The page index parameter must be called `page`
+
+```json
+{
+  "page_size": 100,
+  "_embedded": [
+    {"data": "here"}
+  ],
+  "_links": {
+    "self": {
+      "href": "https://example.com/resource?page_size=100&order=asc&page=3"
+    },
+    "next": {
+      "href": "https://example.com/resource?page_size=100&order=asc&page=4"
+    },
+    "prev": {
+      "href": "https://example.com/resource?page_size=100&order=asc&page=2"
+    }
+  }
+}
+```
 
 API specs
 ---------


### PR DESCRIPTION
After a chat with @afolson we came to the conclusion that cursor based navigation is the best course of action going forwards. This is for three main reasons:

* VAPI already (kind of) uses cursor based navigation (via `record_index`)
* A cursor means no duplicated responses and no missing responses for the user
* Using json/hal and `_links.next` the pagination logic is taken away from the consumer. They just follow the link provided

### Missing data example

Imagine that we have following data set:

```json
[
  {
    "id": 1,
    "text": "one"
  },
  {
    "id": 2,
    "text": "two"
  },
  {
    "id": 3,
    "text": "three"
  },
  {
    "id": 4,
    "text": "four"
  }
]
```

We request this data with `page_size == 2` and `page_index == 0`, returning the following data:

```json
[
  {
    "id": 1,
    "text": "one"
  },
  {
    "id": 2,
    "text": "two"
  }
]
```

Then, between that and our next request (`page_size == 2` and `page_index == 1`) ID 2 is deleted. Our request will return the following:

```json
[
  {
    "id": 4,
    "text": "four"
  }
]
```

ID 3 is never seen as now it belongs to the first page, but we've already accessed that page so we miss it.

The same example with a cursor (`page_size == 2` and `cursor == 2`)

```
[
  {
    "id": 3,
    "text": "three"
  },
  {
    "id": 4,
    "text": "four"
  }
]
```

This works as we tell the API that the latest ID we saw was 2, so show anything newer than that (even if 2 doesn't exist any more).

### Cons of using a cursor

In general, pagination via `page_size` and `page_index` is preferable for users not familiar with APIs. Cursors are designed mainly for high throughput websites (e.g. Twitter and Slack both use cursors).

However, as we provide the next page via `_links.next`, the user just has to follow the link we provide to get the next page of results. This removes the need for them to understand how cursors work meaning that the main disadvantage of cursors is removed.

