### PR TITLE
Update sms.yml

### DIFF
--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -119,9 +119,9 @@ components:
         to:
           description: The number that the message should be sent to
           type: string
-          minLength: 11
-          maxLength: 12
-          pattern: '\d{11,12}'
+          minLength: 7
+          maxLength: 15
+          pattern: '\d{7,15}'
           example: 447700900000
         text:
           description: The body of the message being sent

--- a/lib/nexmo_api_specification/version.rb
+++ b/lib/nexmo_api_specification/version.rb
@@ -1,3 +1,3 @@
 module NexmoApiSpecification
-  VERSION = '0.11.1'.freeze
+  VERSION = '0.11.2'.freeze
 end


### PR DESCRIPTION
corrected the length of a phone number in to: we require e.164 numbers which the specification states has a max length of 15 digits, IIRC the largest in current use is 13 digits.
I can't see a min length in the spec but the shortest length in use is Nieu with a 7 digit e.164 number (3 digit cc and 4 digit national number so that feels like a safe bet