### PR TITLE
Add developer-messages OpenAPI definition

### DIFF
--- a/definitions/developer-messages.yml
+++ b/definitions/developer-messages.yml
@@ -54,10 +54,10 @@ paths:
         '200':
           description: OK
           content:
-            application/json;charset=UTF-8:
+            application/json:
               schema:
                 $ref: '#/components/schemas/message'
-            application/xml;charset=UTF-8:
+            application/xml:
               schema:
                 $ref: '#/components/schemas/message'
   /messages:
@@ -102,10 +102,10 @@ paths:
         '200':
           description: OK
           content:
-            application/json;charset=UTF-8:
+            application/json:
               schema:
                 $ref: '#/components/schemas/messages'
-            application/xml;charset=UTF-8:
+            application/xml:
               schema:
                 $ref: '#/components/schemas/messages'
   /rejections:
@@ -139,10 +139,10 @@ paths:
         '200':
           description: OK
           content:
-            application/json;charset=UTF-8:
+            application/json:
               schema:
                 $ref: '#/components/schemas/rejections'
-            application/xml;charset=UTF-8:
+            application/xml:
               schema:
                 $ref: '#/components/schemas/rejections'
 components:

--- a/definitions/developer-messages.yml
+++ b/definitions/developer-messages.yml
@@ -95,6 +95,7 @@ paths:
         - name: ids
           in: query
           description: The list of up to 10 message IDs to search for.
+          x-nexmo-developer-collection-description-shown: true
           style: form
           explode: true
           schema:
@@ -102,6 +103,7 @@ paths:
             items:
               type: string
               description: A message ID to search for.
+              x-nexmo-developer-collection-description-shown: true
               example: 00A0B0C0
             minItems: 1
             maxItems: 10

--- a/definitions/developer-messages.yml
+++ b/definitions/developer-messages.yml
@@ -1,0 +1,477 @@
+openapi: 3.0.0
+info:
+  title: Nexmo Messages API
+  version: 1.0.0
+  description: >-
+    The Messages API lets you retrieve messages you have sent via the SMS API by
+    ID, as well as retrieve details of messages that were rejected.
+  contact:
+    name: Nexmo.com
+    email: devrel@nexmo.com
+    url: 'https://developer.nexmo.com/'
+    x-twitter: Nexmo
+  termsOfService: 'https://www.nexmo.com/terms-of-use'
+  license:
+    name: The MIT License (MIT)
+    url: 'https://opensource.org/licenses/MIT'
+  x-logo:
+    url: 'https://twitter.com/Nexmo/profile_image?size=original'
+  x-apiClientRegistration: 'https://dashboard.nexmo.com/sign-up'
+servers:
+  - url: 'https://rest.nexmo.com/search'
+externalDocs:
+  url: 'https://developer.nexmo.com/api/developer/messages'
+  x-sha1: d8836c374e2a7504bd2cd59e05fcee440f67cb44
+security:
+  - apiKey: []
+    apiSecret: []
+tags:
+  - name: Search
+    description: Search.
+  - name: Retrieve Multiple
+    description: Retrieve multiple messages.
+  - name: Retrieve Rejected
+    description: Retrieve rejected messages.
+paths:
+  /message:
+    get:
+      description: >-
+        Retrieve information about a single message that you sent using SMS API
+        or that was received on your number.
+      operationId: searchMessage
+      tags:
+        - Search
+      parameters:
+        - name: id
+          in: query
+          required: true
+          description: The ID of the message you want to retrieve.
+          example: 00A0B0C0
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/message'
+            application/xml;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/message'
+  /messages:
+    get:
+      description: >-
+        Retrieve multiple messages that you sent using SMS API or were received
+        on your number. Either `ids` or `date` and `number` are required.
+      operationId: searchMessages
+      tags:
+        - Retrieve Multiple
+      parameters:
+        - name: ids
+          in: query
+          description: The list of up to 10 message IDs to search for.
+          example: 00A0B0C0
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+            minItems: 1
+        - name: date
+          in: query
+          description: >-
+            The date the request to SMS API was submitted in the following
+            format: `YYYY-MM-DD`
+          example: '2020-01-01'
+          schema:
+            type: string
+            format: date
+        - name: to
+          in: query
+          description: The phone number the message was sent to.
+          example: '447700900000'
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/messages'
+            application/xml;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/messages'
+  /rejections:
+    get:
+      description: >-
+        Search for messages that have been rejected by Nexmo. Messages rejected
+        by carrier do not appear.
+      operationId: searchRejections
+      tags:
+        - Search Rejections
+      parameters:
+        - name: date
+          in: query
+          description: >-
+            The date the request to SMS API was submitted in the following
+            format: `YYYY-MM-DD`
+          required: true
+          example: '2020-01-01'
+          schema:
+            type: string
+            format: date
+        - name: to
+          in: query
+          description: The phone number the message was sent to.
+          required: true
+          example: '447700900000'
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/rejections'
+            application/xml;charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/rejections'
+components:
+  schemas:
+    message:
+      type: object
+      properties:
+        type:
+          type: string
+          description: >-
+            The message type. `MT` (mobile terminated or outbound) or `MO`
+            (mobile originated or inbound)
+          example: MT
+          enum:
+            - MT
+            - MO
+        message-id:
+          type: string
+          description: The id of the message you sent.
+          example: 0A00000000ABCD00
+        account-id:
+          $ref: '#/components/schemas/account-id'
+        network:
+          type: string
+          description: >-
+            The [MCCMNC](https://en.wikipedia.org/wiki/Mobile_Network_Code) for
+            the carrier who delivered the message.
+          example: '012345'
+        from:
+          $ref: '#/components/schemas/from'
+        to:
+          $ref: '#/components/schemas/to'
+        body:
+          type: string
+          description: The body of the message.
+          example: A text message sent using the Nexmo SMS API
+        date-received:
+          $ref: '#/components/schemas/date-received'
+        price:
+          type: number
+          description: Price in Euros for a MT message.
+          example: 0.0333
+        date-closed:
+          type: string
+          description: >-
+            The date and time at UTC+0 when Platform received the delivery
+            receipt from the carrier who delivered the MT message. This
+            parameter is in the following format `YYYY-MM-DD HH:MM:SS`.
+          format: date-time
+          example: '2020-01-01 12:00:00'
+        latency:
+          type: number
+          description: >-
+            The overall latency between `date-received` and `date-closed` in
+            milliseconds.
+          example: 3000
+        client-ref:
+          type: string
+          maxLength: 40
+          description: >-
+            The [internal
+            reference](https://developer.nexmo.com/api/sms#send-an-sms) you set
+            in the request.
+          example: my-personal-reference
+        status:
+          type: string
+          description: >-
+            A code that explains where the message is in the delivery process.
+            If status is not `delivered` check `error-code` for more
+            information. If status is `accepted` ignore the value of
+            `error-code`.
+          enum:
+            - delivered
+            - expired
+            - failed
+            - rejected
+            - accepted
+            - buffered
+            - unknown
+          x-ms-enum:
+            name: status
+            values:
+              - value: delivered
+                description: This message has been delivered to the phone number.
+              - value: expired
+                description: >-
+                  The target carrier did not send a status in the 48 hours after
+                  this message was delivered to them.
+              - value: failed
+                description: The target carrier failed to deliver this message.
+              - value: rejected
+                description: The target carrier rejected this message.
+              - value: accepted
+                description: The target carrier has accepted to send this message.
+              - value: buffered
+                description: This message is in the process of being delivered.
+              - value: unknown
+                description: The target carrier has returned an undocumented status code.
+        final-status:
+          type: string
+          description: The status of `message-id` at `date-closed`.
+          enum:
+            - DELIVRD
+            - EXPIRED
+            - UNDELIV
+            - REJECTD
+            - UNKNOWN
+          x-ms-enum:
+            name: final-status
+            values:
+              - value: DELIVRD
+                description: This message has been delivered to the phone number.
+              - value: EXPIRED
+                description: >-
+                  The target carrier did not send a status in the 48 hours after
+                  this message was delivered to them.
+              - value: UNDELIV
+                description: The target carrier failed to deliver this message.
+              - value: REJECTD
+                description: The target carrier rejected this message.
+              - value: UNKNOWN
+                description: The target carrier has returned an undocumented status code.
+          example: DELIVRD
+        error-code:
+          $ref: '#/components/schemas/error-code'
+        error-code-label:
+          $ref: '#/components/schemas/error-code-label'
+      required:
+        - type
+        - message-id
+        - account-id
+        - network
+        - from
+        - to
+        - body
+        - date-received
+    messages:
+      type: object
+      properties:
+        count:
+          type: integer
+          description: The number of messages included in the response.
+        items:
+          type: array
+          xml:
+            wrapped: true
+          items:
+            allOf:
+              - $ref: '#/components/schemas/message'
+              - xml:
+                  name: message
+    rejections:
+      type: object
+      properties:
+        count:
+          type: integer
+          description: The number of messages included in the response.
+        items:
+          type: array
+          xml:
+            wrapped: true
+          items:
+            type: object
+            properties:
+              account-id:
+                $ref: '#/components/schemas/account-id'
+              from:
+                $ref: '#/components/schemas/from'
+              to:
+                $ref: '#/components/schemas/to'
+              date-received:
+                $ref: '#/components/schemas/date-received'
+              error-code:
+                $ref: '#/components/schemas/error-code'
+              error-code-label:
+                $ref: '#/components/schemas/error-code-label'
+            xml:
+              name: rejection
+            required:
+              - account-id
+              - from
+              - to
+              - date-received
+              - error-code
+              - error-code-label
+    account-id:
+      type: string
+      description: Your API Key.
+      example: API_KEY
+    from:
+      type: string
+      description: >-
+        The sender ID the message was sent from. Could be a phone number or
+        name.
+      example: Nexmo
+    to:
+      type: string
+      description: The phone number the message was sent to.
+      example: 447700900000
+    date-received:
+      type: string
+      description: >-
+        The date and time at UTC+0 when Platform received your request in the
+        following format: `YYYY-MM-DD HH:MM:SS`.
+      example: '2020-01-01 12:00:00'
+    error-code:
+      type: string
+      description: Will be set if the `status` is not `accepted`.
+      example: '0'
+      enum:
+        - '0'
+        - '1'
+        - '2'
+        - '3'
+        - '4'
+        - '5'
+        - '6'
+        - '7'
+        - '8'
+        - '9'
+        - '10'
+        - '11'
+        - '12'
+        - '13'
+        - '14'
+        - '15'
+        - '99'
+      x-ms-enum:
+        name: error-code
+        values:
+          - value: '0'
+            description: Delivered.
+          - value: '1'
+            description: >-
+              Unknown - either; An unknown error was received from the carrier
+              who tried to send this this message. _or_ Depending on the
+              carrier, that `to` is unknown. When you see this error, and
+              `status` is rejected, always check if `to` in your request was
+              valid.
+          - value: '2'
+            description: >-
+              Absent Subscriber Temporary - this message was not delivered
+              because `to` was temporarily unavailable. For example, the handset
+              used for `to` was out of coverage or switched off. This is a
+              temporary failure, retry later for a positive result.
+          - value: '3'
+            description: >-
+              Absent Subscriber Permanent - `to` is no longer active, you should
+              remove this phone number from your database.
+          - value: '4'
+            description: >-
+              Call barred by user - you should remove this phone number from
+              your database. If the user wants to receive messages from you,
+              they need to contact their carrier directly.
+          - value: '5'
+            description: >-
+              Portability Error - there is an issue after the user has changed
+              carrier for `to` If the user wants to receive messages from you,
+              they need to contact their carrier directly.
+          - value: '6'
+            description: >-
+              Anti-Spam Rejection - carriers often apply restrictions that block
+              messages following different criteria. For example, on SenderID or
+              message content.
+          - value: '7'
+            description: >-
+              Handset Busy - the handset associated with `to` was not available
+              when this message was sent. If `status` is `Failed` this is a
+              temporary failure; retry later for a positive result. If `status`
+              is `Accepted` this message has is in the retry scheme and will be
+              resent until it expires in 24-48 hours.
+          - value: '8'
+            description: >-
+              Network Error - a network failure while sending your message. This
+              is a temporary failure, retry later for a positive result.
+          - value: '9'
+            description: >-
+              Illegal Number - you tried to send a message to a blacklisted
+              phone number. That is, the user has already sent a STOP opt-out
+              message and no longer wishes to receive messages from you.
+          - value: '10'
+            description: >-
+              Invalid Message - the message could not be sent because one of the
+              parameters in the message was incorrect. For example, incorrect
+              `type` or `udh`
+          - value: '11'
+            description: >-
+              Unroutable - the chosen route to send your message is not
+              available. This is because the phone number is either; Currently
+              on an unsupported _or_ network. On a pre-paid or reseller account
+              that could not receive a message sent by `from` To resolve this
+              issue either email us at
+              [support@nexmo.com](mailto:support@nexmo.com) or create a helpdesk
+              ticket at [https://help.nexmo.com](https://help.nexmo.com).
+          - value: '12'
+            description: >-
+              Destination unreachable - the message could not be delivered to
+              the phone number.
+          - value: '13'
+            description: >-
+              Subscriber Age Restriction - the carrier blocked this message
+              because the content is not suitable for `to` based on age
+              restrictions.
+          - value: '14'
+            description: >-
+              Number Blocked by Carrier - the carrier blocked this message. This
+              could be due to several reasons. For example, `to` s plan does not
+              include SMS or the account is suspended.
+          - value: '15'
+            description: >-
+              Pre-Paid - Insufficent funds - `to`’s pre-paid account does not
+              have enough credit to receive the message.
+          - value: '99'
+            description: >-
+              General Error - there is a problem with the chosen route to send
+              your message. To resolve this issue either email us at
+              [support@nexmo.com](mailto:support@nexmo.com) or create a helpdesk
+              ticket at [https://help.nexmo.com](https://help.nexmo.com).
+    error-code-label:
+      type: string
+      description: A text label to explain `error-code`.
+      example: Delivered
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      name: api_key
+      in: query
+      description: >-
+        You can find your API key in your [account
+        overview](https://dashboard.nexmo.com/account-overview)
+    apiSecret:
+      type: apiKey
+      name: api_secret
+      in: query
+      description: >-
+        You can find your API secret in your [account
+        overview](https://dashboard.nexmo.com/account-overview)

--- a/definitions/developer-messages.yml
+++ b/definitions/developer-messages.yml
@@ -60,6 +60,24 @@ paths:
             application/xml:
               schema:
                 $ref: '#/components/schemas/message'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/message'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/message'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/message'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/message'
   /messages:
     get:
       summary: Search Messages
@@ -108,6 +126,24 @@ paths:
             application/xml:
               schema:
                 $ref: '#/components/schemas/messages'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/messages'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/messages'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/messages'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/messages'
   /rejections:
     get:
       summary: Search for Rejections
@@ -138,6 +174,28 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/rejections'
+                  - $ref: '#/components/schemas/errorJson'
+            application/xml:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/rejections'
+                  - $ref: '#/components/schemas/errorXml'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/rejections'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/rejections'
+        '401':
+          description: Unauthorized
           content:
             application/json:
               schema:
@@ -370,6 +428,8 @@ components:
         - '14'
         - '15'
         - '99'
+        - '400'
+        - '401'
       x-ms-enum:
         name: error-code
         values:
@@ -461,10 +521,52 @@ components:
               your message. To resolve this issue either email us at
               [support@nexmo.com](mailto:support@nexmo.com) or create a helpdesk
               ticket at [https://help.nexmo.com](https://help.nexmo.com).
+          - value: '400'
+            description: wrong parameters
+          - value: '401'
+            description: authentication failed
     error-code-label:
       type: string
       description: A text label to explain `error-code`.
       example: Delivered
+    errorJson:
+      type: object
+      properties:
+        type:
+          type: string
+          example: BAD_REQUEST
+        error_title:
+          type: string
+          example: Bad Request
+        invalid_parameters:
+          type: object
+          additionalProperties:
+            type: string
+            example: Is required.
+    errorXml:
+      type: object
+      xml:
+        name: error
+      properties:
+        type:
+          type: string
+          example: BAD_REQUEST
+        error_title:
+          type: string
+          example: Bad Request
+        invalid_parameters:
+          type: array
+          items:
+            type: object
+            xml:
+              name: entry
+            properties:
+              key:
+                type: string
+                example: date
+              value:
+                type: string
+                example: Is required.
   securitySchemes:
     apiKey:
       type: apiKey

--- a/definitions/developer-messages.yml
+++ b/definitions/developer-messages.yml
@@ -392,9 +392,11 @@ components:
           description: The number of messages included in the response.
         items:
           type: array
+          description: The messages in the response.
           xml:
             wrapped: true
           items:
+            type: object
             xml:
               name: message
             oneOf:

--- a/definitions/developer-messages.yml
+++ b/definitions/developer-messages.yml
@@ -35,6 +35,7 @@ tags:
 paths:
   /message:
     get:
+      summary: Search for Message
       description: >-
         Retrieve information about a single message that you sent using SMS API
         or that was received on your number.
@@ -61,6 +62,7 @@ paths:
                 $ref: '#/components/schemas/message'
   /messages:
     get:
+      summary: Search Messages
       description: >-
         Retrieve multiple messages that you sent using SMS API or were received
         on your number. Either `ids` or `date` and `number` are required.
@@ -71,14 +73,16 @@ paths:
         - name: ids
           in: query
           description: The list of up to 10 message IDs to search for.
-          example: 00A0B0C0
           style: form
           explode: true
           schema:
             type: array
             items:
               type: string
+              description: A message ID to search for.
+              example: 00A0B0C0
             minItems: 1
+            maxItems: 10
         - name: date
           in: query
           description: >-
@@ -106,6 +110,7 @@ paths:
                 $ref: '#/components/schemas/messages'
   /rejections:
     get:
+      summary: Search for Rejections
       description: >-
         Search for messages that have been rejected by Nexmo. Messages rejected
         by carrier do not appear.

--- a/definitions/developer-messages.yml
+++ b/definitions/developer-messages.yml
@@ -86,27 +86,19 @@ paths:
     get:
       summary: Search Messages
       description: >-
-        Retrieve multiple messages that you sent using SMS API or were received
-        on your number. Either `ids` or `date` and `number` are required.
+        Retrieve multiple messages that you sent using the SMS API or that were received
+        on your number. Either one or more `ids` are specified, or both `date` and `number` 
+        are required to identify the messages.
       operationId: searchMessages
       tags:
         - Retrieve Multiple
       parameters:
         - name: ids
           in: query
-          description: The list of up to 10 message IDs to search for.
-          x-nexmo-developer-collection-description-shown: true
-          style: form
-          explode: true
+          description: A message ID to search for. You can specify up to 10 message IDs to search for as query parameters.
+          example: 'ids=123456789&ids=987654321'
           schema:
-            type: array
-            items:
-              type: string
-              description: A message ID to search for.
-              x-nexmo-developer-collection-description-shown: true
-              example: 00A0B0C0
-            minItems: 1
-            maxItems: 10
+            type: string
         - name: date
           in: query
           description: >-

--- a/definitions/developer-messages.yml
+++ b/definitions/developer-messages.yml
@@ -56,28 +56,32 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/message'
+                oneOf:
+                  - $ref: '#/components/schemas/messageBase'
+                  - $ref: '#/components/schemas/messageMT'
             application/xml:
               schema:
-                $ref: '#/components/schemas/message'
+                oneOf:
+                  - $ref: '#/components/schemas/messageBase'
+                  - $ref: '#/components/schemas/messageMT'
         '400':
           description: Bad request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/message'
+                $ref: '#/components/schemas/errorJson'
             application/xml:
               schema:
-                $ref: '#/components/schemas/message'
+                $ref: '#/components/schemas/errorXml'
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/message'
+                $ref: '#/components/schemas/error'
             application/xml:
               schema:
-                $ref: '#/components/schemas/message'
+                $ref: '#/components/schemas/error'
   /messages:
     get:
       summary: Search Messages
@@ -131,19 +135,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/messages'
+                $ref: '#/components/schemas/errorJson'
             application/xml:
               schema:
-                $ref: '#/components/schemas/messages'
+                $ref: '#/components/schemas/errorXml'
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/messages'
+                $ref: '#/components/schemas/error'
             application/xml:
               schema:
-                $ref: '#/components/schemas/messages'
+                $ref: '#/components/schemas/error'
   /rejections:
     get:
       summary: Search for Rejections
@@ -152,7 +156,7 @@ paths:
         by carrier do not appear.
       operationId: searchRejections
       tags:
-        - Search Rejections
+        - Retrieve Rejected
       parameters:
         - name: date
           in: query
@@ -177,36 +181,103 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/rejections'
-                  - $ref: '#/components/schemas/errorJson'
+                $ref: '#/components/schemas/rejections'
             application/xml:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/rejections'
-                  - $ref: '#/components/schemas/errorXml'
+                $ref: '#/components/schemas/rejections'
         '400':
           description: Bad request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rejections'
+                $ref: '#/components/schemas/errorJson'
             application/xml:
               schema:
-                $ref: '#/components/schemas/rejections'
+                $ref: '#/components/schemas/errorXml'
         '401':
           description: Unauthorized
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rejections'
+                $ref: '#/components/schemas/error'
             application/xml:
               schema:
-                $ref: '#/components/schemas/rejections'
+                $ref: '#/components/schemas/error'
 components:
   schemas:
-    message:
+    messageBase:
       type: object
+      required:
+        - type
+        - message-id
+        - account-id
+        - network
+        - from
+        - to
+        - body
+        - date-received
+      xml:
+        name: message
+      properties:
+        type:
+          type: string
+          description: >-
+            The message type. `MT` (mobile terminated or outbound) or `MO`
+            (mobile originated or inbound)
+          example: MO
+          enum:
+            - MO
+        message-id:
+          type: string
+          description: The id of the message you sent.
+          example: 0A00000000ABCD00
+        account-id:
+          type: string
+          description: Your API Key.
+          example: API_KEY
+        date-received:
+          type: string
+          description: >-
+            The date and time at UTC+0 when Platform received your request in
+            the following format: `YYYY-MM-DD HH:MM:SS`.
+          example: '2020-01-01 12:00:00'
+        network:
+          type: string
+          description: >-
+            The [MCCMNC](https://en.wikipedia.org/wiki/Mobile_Network_Code) for
+            the carrier who delivered the message.
+          example: '012345'
+        from:
+          type: string
+          description: >-
+            The sender ID the message was sent from. Could be a phone number or
+            name.
+          example: Nexmo
+        to:
+          type: string
+          description: The phone number the message was sent to.
+          example: 447700900000
+        body:
+          type: string
+          description: The body of the message.
+          example: A text message sent using the Nexmo SMS API
+    messageMT:
+      type: object
+      required:
+        - type
+        - message-id
+        - account-id
+        - network
+        - from
+        - to
+        - body
+        - date-received
+        - price
+        - final-status
+        - date-closed
+        - latency
+      xml:
+        name: message
       properties:
         type:
           type: string
@@ -216,29 +287,20 @@ components:
           example: MT
           enum:
             - MT
-            - MO
         message-id:
-          type: string
-          description: The id of the message you sent.
-          example: 0A00000000ABCD00
+          $ref: '#/components/schemas/messageBase/properties/message-id'
         account-id:
-          $ref: '#/components/schemas/account-id'
+          $ref: '#/components/schemas/messageBase/properties/account-id'
         network:
-          type: string
-          description: >-
-            The [MCCMNC](https://en.wikipedia.org/wiki/Mobile_Network_Code) for
-            the carrier who delivered the message.
-          example: '012345'
+          $ref: '#/components/schemas/messageBase/properties/network'
         from:
-          $ref: '#/components/schemas/from'
+          $ref: '#/components/schemas/messageBase/properties/from'
         to:
-          $ref: '#/components/schemas/to'
+          $ref: '#/components/schemas/messageBase/properties/to'
         body:
-          type: string
-          description: The body of the message.
-          example: A text message sent using the Nexmo SMS API
+          $ref: '#/components/schemas/messageBase/properties/body'
         date-received:
-          $ref: '#/components/schemas/date-received'
+          $ref: '#/components/schemas/messageBase/properties/date-received'
         price:
           type: number
           description: Price in Euros for a MT message.
@@ -328,15 +390,6 @@ components:
           $ref: '#/components/schemas/error-code'
         error-code-label:
           $ref: '#/components/schemas/error-code-label'
-      required:
-        - type
-        - message-id
-        - account-id
-        - network
-        - from
-        - to
-        - body
-        - date-received
     messages:
       type: object
       properties:
@@ -348,10 +401,11 @@ components:
           xml:
             wrapped: true
           items:
-            allOf:
-              - $ref: '#/components/schemas/message'
-              - xml:
-                  name: message
+            xml:
+              name: message
+            oneOf:
+              - $ref: '#/components/schemas/messageBase'
+              - $ref: '#/components/schemas/messageMT'
     rejections:
       type: object
       properties:
@@ -366,13 +420,13 @@ components:
             type: object
             properties:
               account-id:
-                $ref: '#/components/schemas/account-id'
+                $ref: '#/components/schemas/messageBase/properties/account-id'
               from:
-                $ref: '#/components/schemas/from'
+                $ref: '#/components/schemas/messageBase/properties/from'
               to:
-                $ref: '#/components/schemas/to'
+                $ref: '#/components/schemas/messageBase/properties/to'
               date-received:
-                $ref: '#/components/schemas/date-received'
+                $ref: '#/components/schemas/messageBase/properties/date-received'
               error-code:
                 $ref: '#/components/schemas/error-code'
               error-code-label:
@@ -386,26 +440,6 @@ components:
               - date-received
               - error-code
               - error-code-label
-    account-id:
-      type: string
-      description: Your API Key.
-      example: API_KEY
-    from:
-      type: string
-      description: >-
-        The sender ID the message was sent from. Could be a phone number or
-        name.
-      example: Nexmo
-    to:
-      type: string
-      description: The phone number the message was sent to.
-      example: 447700900000
-    date-received:
-      type: string
-      description: >-
-        The date and time at UTC+0 when Platform received your request in the
-        following format: `YYYY-MM-DD HH:MM:SS`.
-      example: '2020-01-01 12:00:00'
     error-code:
       type: string
       description: Will be set if the `status` is not `accepted`.
@@ -529,6 +563,13 @@ components:
       type: string
       description: A text label to explain `error-code`.
       example: Delivered
+    error:
+      type: object
+      properties:
+        error-code:
+          $ref: '#/components/schemas/error-code'
+        error-code-label:
+          $ref: '#/components/schemas/error-code-label'
     errorJson:
       type: object
       properties:


### PR DESCRIPTION
First cut of developer-messages API definition

* Includes only `200` responses for now as per @adambutler 
* Avoids use of `oneOf` in response schemas (https://github.com/swagger-api/swagger-ui/issues/3803#issuecomment-377905800)
* Response media-types are as returned by the API (includes `charset`)