### PR TITLE
Add application OpenAPI definition

### DIFF
--- a/definitions/application.yml
+++ b/definitions/application.yml
@@ -1,0 +1,397 @@
+openapi: 3.0.0
+info:
+  title: Nexmo Application API
+  version: 1.0.0
+  description: >-
+    A Nexmo application contains the security and configuration information you
+    need to connect to Nexmo endpoints and easily use our products.
+  contact:
+    name: Nexmo.com
+    email: devrel@nexmo.com
+    url: 'https://developer.nexmo.com/'
+    x-twitter: Nexmo
+  termsOfService: 'https://www.nexmo.com/terms-of-use'
+  license:
+    name: The MIT License (MIT)
+    url: 'https://opensource.org/licenses/MIT'
+  x-logo:
+    url: 'https://twitter.com/Nexmo/profile_image?size=original'
+  x-apiClientRegistration: 'https://dashboard.nexmo.com/sign-up'
+servers:
+  - url: 'https://api.nexmo.com/v1/applications'
+externalDocs:
+  url: 'https://developer.nexmo.com/api/developer/application'
+  x-sha1: d8836c374e2a7504bd2cd59e05fcee440f67cb44
+security:
+  - apiKey: []
+    apiSecret: []
+tags:
+  - name: Create
+    description: Create an application
+  - name: Retrieve All
+    description: Retrieve your applications
+  - name: Retrieve
+    description: Retrieve an application
+  - name: Update
+    description: Update an application
+  - name: Destroy
+    description: Delete an application
+paths:
+  /:
+    post:
+      summary: Create Application
+      description: You use a `POST` request to create a new application.
+      operationId: createApplication
+      tags:
+        - Create
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - name
+                - type
+                - answer_url
+                - event_url
+              properties:
+                name:
+                  description: The name of your application.
+                  type: string
+                  example: My Application
+                type:
+                  description: >-
+                    The Nexmo product or products that you access with this
+                    application. Currently only `voice` is supported.
+                  type: string
+                  example: voice
+                answer_url:
+                  description: >-
+                    The URL where your webhook delivers the Nexmo Call Control
+                    Object that governs this call. As soon as your user answers
+                    a call Nexmo makes a request to `answer_url`.
+                  type: string
+                  example: 'https://example.com'
+                answer_method:
+                  description: >-
+                    The HTTP method used to make the request to `answer_url`.
+                    The default value is `GET`.
+                  type: string
+                  example: GET
+                event_url:
+                  description: >-
+                    Nexmo sends event information asynchronously to this URL
+                    when status changes.
+                  type: string
+                  example: 'https://example.com'
+                event_method:
+                  description: >-
+                    The HTTP method used to send event information to event_url.
+                    The default value is `POST`.
+                  type: string
+                  example: POST
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/application'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/application'
+    get:
+      summary: Retrieve all Applications
+      description: >-
+        You use a `GET` request to retrieve details of all applications
+        associated with your account.
+      operationId: retrieveApplications
+      tags:
+        - Retrieve All
+      parameters:
+        - name: page_size
+          required: false
+          in: query
+          description: >-
+            Set the number of items returned on each call to this endpoint. The
+            default is 10 records.
+          schema:
+            type: integer
+            default: 10
+          example: 10
+        - name: page_index
+          required: false
+          in: query
+          description: Set the offset from the first page. The default value is `0`.
+          schema:
+            type: integer
+            default: 0
+          example: 0
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/applications'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/applications'
+  '/{app_id}':
+    get:
+      summary: Retrieve Application
+      description: You use a `GET` request to retrieve details about a single application.
+      operationId: retrieveApplication
+      tags:
+        - Retrieve
+      parameters:
+        - $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/application'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/application'
+    put:
+      summary: Update Application
+      description: You use a `PUT` request to update an existing application.
+      operationId: updateApplication
+      tags:
+        - Update
+      parameters:
+        - $ref: '#/components/parameters/app_id'
+        - name: name
+          required: true
+          in: query
+          description: The name of your application.
+          schema:
+            type: string
+          example: UpdatedApplication
+        - name: type
+          required: true
+          in: query
+          description: >-
+            The Nexmo product or products that you access with this application.
+            Currently only `voice` is supported.
+          schema:
+            type: string
+            enum:
+              - voice
+          example: voice
+        - name: answer_url
+          required: true
+          in: query
+          description: >-
+            The URL where your webhook delivers the Nexmo Call Control Object
+            that governs this call. As soon as your user answers a call Nexmo
+            makes a request to `answer_url`.
+          schema:
+            type: string
+            format: url
+          example: 'https://example.com/ncco'
+        - name: answer_method
+          required: false
+          in: query
+          description: >-
+            The HTTP method used to make the request to `answer_url`. The
+            default value is `GET`.
+          schema:
+            type: string
+            default: GET
+          example: GET
+        - name: event_url
+          required: true
+          in: query
+          description: >-
+            Nexmo sends event information asynchronously to this URL when status
+            changes.
+          schema:
+            type: string
+            format: url
+          example: 'https://example.com/call_status'
+        - name: event_method
+          required: false
+          in: query
+          description: >-
+            The HTTP method used to send event information to event_url. The
+            default value is POST.
+          schema:
+            type: string
+            default: POST
+          example: POST
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/application'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/application'
+    delete:
+      summary: Destroy Application
+      description: You use a `DELETE` request to delete a single application.
+      operationId: deleteApplication
+      tags:
+        - Destroy
+      parameters:
+        - $ref: '#/components/parameters/app_id'
+      responses:
+        '204':
+          description: No content
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      name: api_key
+      in: query
+      description: >-
+        You can find your API key in your [account
+        overview](https://dashboard.nexmo.com/account-overview)
+    apiSecret:
+      type: apiKey
+      name: api_secret
+      in: query
+      description: >-
+        You can find your API secret in your [account
+        overview](https://dashboard.nexmo.com/account-overview)
+  parameters:
+    app_id:
+      name: app_id
+      in: path
+      required: true
+      description: The ID allocated to your application by Nexmo.
+      schema:
+        type: string
+      example: aaaaaaaa-bbbb-cccc-dddd-0123456789ab
+  schemas:
+    links:
+      type: object
+      description: >-
+        A series of links between resources in this API in the following [HAL
+        specification](http://stateless.co/hal_specification.html).
+      additionalProperties:
+        type: object
+        properties:
+          href:
+            type: string
+            format: url
+            description: The link URL.
+            example: /v1/applications/aaaaaaaa-bbbb-cccc-dddd-0123456789ab
+    application:
+      type: object
+      required:
+        - name
+        - voice
+      properties:
+        id:
+          description: The ID allocated to your application by Nexmo.
+          type: string
+          example: aaaaaaaa-bbbb-cccc-dddd-0123456789ab
+        name:
+          description: The name of your application
+          type: string
+          example: My Application
+        voice:
+          description: >-
+            The Nexmo product or products that you access with this application.
+            Currently only `voice` is supported.
+          type: object
+          properties:
+            webhooks:
+              type: array
+              items:
+                type: object
+                required:
+                  - endpoint_type
+                  - endpoint
+                  - http_method
+                properties:
+                  endpoint_type:
+                    type: string
+                    enum:
+                      - answer_url
+                      - event_url
+                    example: answer_url
+                  endpoint:
+                    type: string
+                    description: >-
+                      * `answer_url`: The URL where your webhook delivers the
+                      Nexmo Call Control Object that governs this call. As soon
+                      as your user answers a call Nexmo makes a request to
+                      answer_url. * `event_url`: Nexmo sends event information
+                      asynchronously to this URL when status changes.
+                    format: url
+                    example: 'https://example.com'
+                  http_method:
+                    type: string
+                    description: >-
+                      The HTTP method used to send event information to the
+                      event_url or answer_url.
+                    enum:
+                      - GET
+                      - POST
+                    example: GET
+            keys:
+              type: object
+              required:
+                - public_key
+              properties:
+                public_key:
+                  description: >-
+                    The public key used to validate the
+                    [JWT](https://en.wikipedia.org/wiki/JSON_Web_Token).
+                  type: string
+                  example: PUBLIC_KEY
+                private_key:
+                  description: >-
+                    The private key you use to generate the JSON Web Token (JWT)
+                    that authenticates your requests to Voice API.
+                  type: string
+                  example: PRIVATE_KEY
+            _links:
+              $ref: '#/components/schemas/links'
+    applications:
+      type: object
+      required:
+        - count
+        - page_size
+        - page_index
+        - _embedded
+      properties:
+        count:
+          description: The number of items associated with your account.
+          type: integer
+          example: 1
+        page_size:
+          description: >-
+            The number of items returned on each call to this endpoint. The
+            default is 10 records.
+          type: integer
+          example: 10
+        page_index:
+          description: The offset from the first page.
+          type: integer
+          example: 1
+        _embedded:
+          type: object
+          xml:
+            name: applications
+          properties:
+            applications:
+              type: array
+              xml:
+                name: application
+              description: >-
+                The collection of your applications. Each object contains
+                information about an an individual application. The public_key
+                is not included in the application information.
+              items:
+                $ref: '#/components/schemas/application'
+        _links:
+          $ref: '#/components/schemas/links'

--- a/definitions/application.yml
+++ b/definitions/application.yml
@@ -99,7 +99,7 @@ paths:
                 $ref: '#/components/schemas/application'
             application/xml:
               schema:
-                $ref: '#/components/schemas/application'
+                $ref: '#/components/schemas/applicationXml'
     get:
       summary: Retrieve all Applications
       description: >-
@@ -136,7 +136,7 @@ paths:
                 $ref: '#/components/schemas/applications'
             application/xml:
               schema:
-                $ref: '#/components/schemas/applications'
+                $ref: '#/components/schemas/applicationsXml'
   '/{app_id}':
     get:
       summary: Retrieve Application
@@ -155,7 +155,7 @@ paths:
                 $ref: '#/components/schemas/application'
             application/xml:
               schema:
-                $ref: '#/components/schemas/application'
+                $ref: '#/components/schemas/applicationXml'
     put:
       summary: Update Application
       description: You use a `PUT` request to update an existing application.
@@ -232,7 +232,7 @@ paths:
                 $ref: '#/components/schemas/application'
             application/xml:
               schema:
-                $ref: '#/components/schemas/application'
+                $ref: '#/components/schemas/applicationXml'
     delete:
       summary: Destroy Application
       description: You use a `DELETE` request to delete a single application.
@@ -283,11 +283,103 @@ components:
             format: url
             description: The link URL.
             example: /v1/applications/aaaaaaaa-bbbb-cccc-dddd-0123456789ab
+    voiceXml:
+      description: >-
+        The Nexmo product or products that you access with this application.
+        Currently only `voice` is supported.
+      type: object
+      properties:
+        webhooks:
+          $ref: '#/components/schemas/voiceBase/properties/webhooks'
+        keys:
+          $ref: '#/components/schemas/voiceBase/properties/keys'
+    voiceBase:
+      description: >-
+        The Nexmo product or products that you access with this application.
+        Currently only `voice` is supported.
+      type: object
+      properties:
+        webhooks:
+          type: array
+          items:
+            type: object
+            required:
+              - endpoint_type
+              - endpoint
+              - http_method
+            properties:
+              endpoint_type:
+                type: string
+                enum:
+                  - answer_url
+                  - event_url
+                example: answer_url
+              endpoint:
+                type: string
+                description: >-
+                  * `answer_url`: The URL where your webhook delivers the Nexmo
+                  Call Control Object that governs this call. As soon as your
+                  user answers a call Nexmo makes a request to answer_url. *
+                  `event_url`: Nexmo sends event information asynchronously to
+                  this URL when status changes.
+                format: url
+                example: 'https://example.com'
+              http_method:
+                type: string
+                description: >-
+                  The HTTP method used to send event information to the
+                  event_url or answer_url.
+                enum:
+                  - GET
+                  - POST
+                example: GET
+        keys:
+          type: object
+          required:
+            - public_key
+          properties:
+            public_key:
+              description: >-
+                The public key used to validate the
+                [JWT](https://en.wikipedia.org/wiki/JSON_Web_Token).
+              type: string
+              example: PUBLIC_KEY
+            private_key:
+              description: >-
+                The private key you use to generate the JSON Web Token (JWT)
+                that authenticates your requests to Voice API.
+              type: string
+              example: PRIVATE_KEY
+        _links:
+          $ref: '#/components/schemas/links'
     application:
       type: object
       required:
         - name
         - voice
+      properties:
+        id:
+          $ref: '#/components/schemas/applicationBase/properties/id'
+        name:
+          $ref: '#/components/schemas/applicationBase/properties/name'
+        voice:
+          $ref: '#/components/schemas/voiceBase'
+    applicationXml:
+      type: object
+      required:
+        - name
+        - voice
+      xml:
+        name: application
+      properties:
+        id:
+          $ref: '#/components/schemas/applicationBase/properties/id'
+        name:
+          $ref: '#/components/schemas/applicationBase/properties/name'
+        voice:
+          $ref: '#/components/schemas/voiceXml'
+    applicationBase:
+      type: object
       properties:
         id:
           description: The ID allocated to your application by Nexmo.
@@ -297,65 +389,6 @@ components:
           description: The name of your application
           type: string
           example: My Application
-        voice:
-          description: >-
-            The Nexmo product or products that you access with this application.
-            Currently only `voice` is supported.
-          type: object
-          properties:
-            webhooks:
-              type: array
-              items:
-                type: object
-                required:
-                  - endpoint_type
-                  - endpoint
-                  - http_method
-                properties:
-                  endpoint_type:
-                    type: string
-                    enum:
-                      - answer_url
-                      - event_url
-                    example: answer_url
-                  endpoint:
-                    type: string
-                    description: >-
-                      * `answer_url`: The URL where your webhook delivers the
-                      Nexmo Call Control Object that governs this call. As soon
-                      as your user answers a call Nexmo makes a request to
-                      answer_url. * `event_url`: Nexmo sends event information
-                      asynchronously to this URL when status changes.
-                    format: url
-                    example: 'https://example.com'
-                  http_method:
-                    type: string
-                    description: >-
-                      The HTTP method used to send event information to the
-                      event_url or answer_url.
-                    enum:
-                      - GET
-                      - POST
-                    example: GET
-            keys:
-              type: object
-              required:
-                - public_key
-              properties:
-                public_key:
-                  description: >-
-                    The public key used to validate the
-                    [JWT](https://en.wikipedia.org/wiki/JSON_Web_Token).
-                  type: string
-                  example: PUBLIC_KEY
-                private_key:
-                  description: >-
-                    The private key you use to generate the JSON Web Token (JWT)
-                    that authenticates your requests to Voice API.
-                  type: string
-                  example: PRIVATE_KEY
-            _links:
-              $ref: '#/components/schemas/links'
     applications:
       type: object
       required:
@@ -363,6 +396,37 @@ components:
         - page_size
         - page_index
         - _embedded
+        - _links
+      properties:
+        count:
+          $ref: '#/components/schemas/applicationsBase/properties/count'
+        page_size:
+          $ref: '#/components/schemas/applicationsBase/properties/page_size'
+        page_index:
+          $ref: '#/components/schemas/applicationsBase/properties/page_index'
+        _embedded:
+          $ref: '#/components/schemas/applicationsBase/properties/_embedded'
+        _links:
+          $ref: '#/components/schemas/links'
+    applicationsXml:
+      type: object
+      required:
+        - count
+        - page_size
+        - page_index
+        - _embedded
+      xml:
+        name: applications
+      properties:
+        count:
+          $ref: '#/components/schemas/applicationsBase/properties/count'
+        page_size:
+          $ref: '#/components/schemas/applicationsBase/properties/page_size'
+        page_index:
+          $ref: '#/components/schemas/applicationsBase/properties/page_index'
+        voice:
+          $ref: '#/components/schemas/voiceXml'
+    applicationsBase:
       properties:
         count:
           description: The number of items associated with your account.
@@ -393,5 +457,3 @@ components:
                 is not included in the application information.
               items:
                 $ref: '#/components/schemas/application'
-        _links:
-          $ref: '#/components/schemas/links'


### PR DESCRIPTION
First cut of application API OpenAPI definition.

* May need some additional `minLength` / `maxLength` properties
* I've described the properties from HAL which appear in the responses (e.g. `_embedded` and `_links`), let me know if anything else needs documenting such as 'curies' or taking descriptions from the HAL specification
* `_links` don't seem to appear in xml responses, but I've re-used the same schema for simplicity