### PR TITLE
Support requested clarification of message type.

### DIFF
--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -124,7 +124,7 @@ components:
           pattern: '\d{7,15}'
           example: 447700900000
         text:
-          description: The body of the message being sent
+          description: The body of the message being sent. If your message contains characters that can be encoded according to the GSM Standard and Extended tables then you can set the `type` to `text`. If your message contains characters outside this range, then you will need to set the `type` to `unicode`.
           type: string
           example: Hello World!
         ttl:


### PR DESCRIPTION
My understanding is:

"If your message contains characters that can be encoded according to the GSM Standard and Extended tables then you can set the `type` to `text`. If your message contains characters outside this range, then you will need to set the `type` to `unicode`."

However, my understanding may not be correct, so I would be really grateful if someone could confirm this one way or the other. 