### PR TITLE
fix: incorrect reference to Message change to higher level SMS schema

### DIFF
--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -62,7 +62,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Message'
+                $ref: '#/components/schemas/SMS'
             text/xml:
               schema:
                 $ref: '#/components/schemas/MessageXmlWrapper'

--- a/lib/nexmo_api_specification/version.rb
+++ b/lib/nexmo_api_specification/version.rb
@@ -1,3 +1,3 @@
 module NexmoApiSpecification
-  VERSION = '0.11.6'.freeze
+  VERSION = '0.11.7'.freeze
 end


### PR DESCRIPTION
This issue was raised in the documentation repo but it applies here.

https://github.com/Nexmo/nexmo-developer/issues/1016

The JSON response was referencing the schema Message where it should return the whole SMS schema.  

The response stated that one message would be returned where there will be an array of messages returned with a message count.

Changed the reference to SMS instead of message and bumped the minor version

XML reference is fine.