### PR TITLE
Add link to error status codes in Troubleshooting Failed SMS concept doc

### DIFF
--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -321,7 +321,7 @@ components:
             name: messageId
         status:
           type: string
-          description: The status of the message
+          description: The status of the message. See [Troubleshooting Failed SMS](/messaging/sms/guides/troubleshooting-sms).
           example: '0'
         remaining-balance:
           type: string


### PR DESCRIPTION
Responding to urgent request from support to document these. The new Troubleshooting Failed SMS concept doc is PR1162 on `nexmo-developer`.

@mheap Would appreciate your help getting this into NDP.