### PR TITLE
Remove deprecated subscription_type field

### DIFF
--- a/definitions/number-insight.yml
+++ b/definitions/number-insight.yml
@@ -446,10 +446,6 @@ components:
               example: 'Smith'
               xml:
                 attribute: true
-            subscription-type:
-              example: unknown
-              xml:
-                attribute: true
           caller_name:
             type: string
             description: 'Full name of the person or business who owns the phone number. `unknown` if this information is not available. This parameter is only present if `cnam` had a value of `true` within the request.'
@@ -607,10 +603,6 @@ components:
               type: string
               description: 'Last name of the person who owns the phone number if the owner is an individual. This parameter is only present if `cnam` had a value of `true` within the request.'
               example: 'Smith'
-              xml:
-                attribute: true
-            subscription-type:
-              example: unknown
               xml:
                 attribute: true
         caller_name:
@@ -1098,10 +1090,6 @@ components:
           type: string
           description: 'Last name of the person who owns the phone number if the owner is an individual. This parameter is only present if `cnam` had a value of `true` within the request.'
           example: 'Smith'
-        subscription_type:
-          type: string
-          # @TODO: description: ''
-          example: 'unknown'
 
     niBasicStatus:
       type: integer


### PR DESCRIPTION
JP informs us that the `subscription_type` field - which was never properly documented - is deprecated anyway, so removing.