### PR TITLE
Update x-groups to tags

### DIFF
--- a/definitions/conversation.yml
+++ b/definitions/conversation.yml
@@ -15,7 +15,8 @@ paths:
     post:
       x-swagger-router-controller: createConversation
       operationId: createConversation
-      x-group: conversation
+      tags:
+        - conversation
       summary: Create a conversation
       responses:
         '200':
@@ -25,7 +26,8 @@ paths:
     get:
       x-swagger-router-controller: listConversations
       operationId: listConversations
-      x-group: conversation
+      tags:
+        - conversation
       summary: List conversations
       description: >
           List all conversations associated with your application. 
@@ -88,7 +90,8 @@ paths:
     put:
       x-swagger-router-controller: conversations
       operationId: replaceConversation
-      x-group: conversation
+      tags:
+        - conversation
       summary: Update a conversation
       responses:
         '200':
@@ -98,7 +101,8 @@ paths:
     get:
       x-swagger-router-controller: retrieveConversation
       operationId: retrieveConversation
-      x-group: conversation
+      tags:
+        - conversation
       summary: Retrieve a conversation
       responses:
         '200':
@@ -160,7 +164,8 @@ paths:
     delete:
       x-swagger-router-controller: deleteConversation
       operationId: deleteConversation
-      x-group: conversation
+      tags:
+        - conversation
       summary: Delete a conversation
       responses:
         '200':
@@ -171,7 +176,8 @@ paths:
     post:
       x-swagger-router-controller: createEvent
       operationId: createEvent
-      x-group: event
+      tags:
+        - event
       summary: Create an event
       requestBody:
         content:
@@ -209,7 +215,8 @@ paths:
     get:
       x-swagger-router-controller: getEvents
       operationId: getEvents
-      x-group: event
+      tags:
+        - event
       summary: List events
       responses:
         '200':
@@ -227,7 +234,8 @@ paths:
     get:
       x-swagger-router-controller: getEvent
       operationId: getEvent
-      x-group: event
+      tags:
+        - event
       summary: Retrieve an event
       responses:
         '200':
@@ -239,7 +247,8 @@ paths:
     delete:
       x-swagger-router-controller: deleteEvent
       operationId: deleteEvent
-      x-group: event
+      tags:
+        - event
       summary: Delete an event
       responses:
         '200':
@@ -250,7 +259,8 @@ paths:
     get:
       x-swagger-router-controller: members
       operationId: getMembers
-      x-group: member
+      tags:
+        - member
       summary: List members
       responses:
         '200':
@@ -278,7 +288,8 @@ paths:
     post:
       x-swagger-router-controller: members
       operationId: createMember
-      x-group: member
+      tags:
+        - member
       summary: Create a member
       responses:
         '201':
@@ -333,7 +344,8 @@ paths:
     get:
       x-swagger-router-controller: members
       operationId: getMember
-      x-group: member
+      tags:
+        - member
       summary: Retrieve a member
       responses:
         '200':
@@ -349,7 +361,8 @@ paths:
     put:
       x-swagger-router-controller: members
       operationId: updateMember
-      x-group: member
+      tags:
+        - member
       summary: Update a member
       responses:
         '200':
@@ -374,7 +387,8 @@ paths:
     delete:
       x-swagger-router-controller: members
       operationId: deleteMember
-      x-group: member
+      tags:
+        - member
       summary: Delete a member
       responses:
         '200':
@@ -383,7 +397,8 @@ paths:
     get:
       x-swagger-router-controller: users
       operationId: getUsers
-      x-group: user
+      tags:
+        - user
       summary: List users
       responses:
         '200':
@@ -404,7 +419,8 @@ paths:
     post:
       x-swagger-router-controller: users
       operationId: createUser
-      x-group: user
+      tags:
+        - user
       summary: Create a user
       description: 'Note: Users must be created with an admin JWT.'
       responses:
@@ -442,7 +458,8 @@ paths:
     get:
       x-swagger-router-controller: users
       operationId: getUser
-      x-group: user
+      tags:
+        - user
       summary: Retrieve a user
       responses:
         '200':
@@ -463,7 +480,8 @@ paths:
     put:
       x-swagger-router-controller: users
       operationId: updateUser
-      x-group: user
+      tags:
+        - user
       summary: Update a user
       responses:
         '200':
@@ -492,7 +510,8 @@ paths:
     delete:
       x-swagger-router-controller: users
       operationId: deleteUser
-      x-group: user
+      tags:
+        - user
       summary: Delete a user
       responses:
         '200':
@@ -503,7 +522,8 @@ paths:
     get:
       x-swagger-router-controller: users
       operationId: getuserConversations
-      x-group: user
+      tags:
+        - user
       summary: List user conversations
       responses:
         '200':
@@ -543,7 +563,8 @@ paths:
     get:
       x-swagger-router-controller: listLegs
       operationId: listLegs
-      x-group: leg
+      tags:
+        - leg
       summary: List legs
       responses:
         '200':
@@ -646,7 +667,8 @@ paths:
     delete:
       x-swagger-router-controller: deleteLeg
       operationId: deleteLeg
-      x-group: leg
+      tags:
+        - leg
       summary: Delete a leg
       responses:
         '200':
@@ -1122,28 +1144,17 @@ components:
       bearerFormat: JWT
 security:
   - bearerAuth: []
-x-groups:
-  conversation:
-    name: Conversation
-    order: 1
+
+tags:
+  - name: Conversation
     description: A conversation is a shared core component that Nexmo APIs rely on. Conversations happen over multiple mediums and and can have associated Users through Memberships.
-  user:
-    name: User
-    order: 2
+  - name: User
     description: 'The concept of a user exists in Nexmo APIs, you can associate one with a user in your own application if you choose. A user can have multiple memberships to conversations and can communicate with other users through various different mediums.'
-  member:
-    name: Member
-    order: 3
+  - name: Member
     description: Memberships connect users with conversations. Each membership has one conversation and one user however a user can have many memberships to conversations just as conversations can have many members.
-  event:
-    name: Event
-    order: 4
+  - name: Event
     description: 'Events are actions that occur within a conversation. Examples of this includes: Text events from members, or invite events from users'
-  leg:
-    name: Leg
-    order: 5
+  - name: Leg
     description: 'A leg can be a video call, IP call, or PSTN call that users participate in using multiple platforms. With this endpoint you can retrieve the details about all of the legs that took place in your application.'
-  rtc:
-    name: Rtc
-    order: 6
+  - name: Rtc
     description: Rtc actions. Any rtc action related (like starting a new rtc connection).

--- a/definitions/external-accounts.yml
+++ b/definitions/external-accounts.yml
@@ -19,7 +19,8 @@ paths:
       - basicAuth: []
       summary: Create a Messenger account
       operationId: CreateMessengerAccount
-      x-group: messenger
+      tags:
+        - messenger
       requestBody:
         required: true
         content:
@@ -115,7 +116,8 @@ paths:
       - basicAuth: []
       summary: Retrieve a Messenger account
       operationId: GetMessengerAccount
-      x-group: messenger
+      tags:
+        - messenger
       parameters:
       - in: path
         name: external_id
@@ -144,7 +146,8 @@ paths:
       - basicAuth: []
       summary: Update a Messenger account
       operationId: UpdateMessengerAccount
-      x-group: messenger
+      tags:
+        - messenger
       parameters:
       - in: path
         name: external_id
@@ -263,7 +266,8 @@ paths:
       - basicAuth: []
       summary: Delete a Messenger account
       operationId: DeleteMessengerAccount
-      x-group: messenger
+      tags:
+        - messenger
       parameters:
       - in: path
         name: external_id
@@ -295,7 +299,8 @@ paths:
       - basicAuth: []
       summary: Retrieve a Viber Service Message account
       operationId: GetVSMAccount
-      x-group: viber_service_msg
+      tags:
+        - viber_service_msg
       parameters:
       - in: path
         name: external_id
@@ -325,7 +330,8 @@ paths:
       - basicAuth: []
       summary: Retrieve a Whatsapp account
       operationId: GetWAAccount
-      x-group: whatsapp
+      tags:
+        - whatsapp
       parameters:
       - in: path
         name: external_id
@@ -355,7 +361,8 @@ paths:
       - basicAuth: []
       summary: Retrieve all accounts you own
       operationId: GetAllAccounts
-      x-group: account
+      tags:
+        - account
       parameters:
       - in: query
         name: provider
@@ -447,7 +454,8 @@ paths:
       - basicAuth: []
       summary: Link application to an account
       operationId: LinkApplication
-      x-group: applications
+      tags:
+        - applications
       parameters:
       - in: path
         name: provider
@@ -533,7 +541,8 @@ paths:
       - basicAuth: []
       summary: Unlink application from an account
       operationId: UnliWithoutApplicationnkApplication
-      x-group: applications
+      tags:
+        - applications
       parameters:
       - in: path
         name: provider
@@ -766,24 +775,14 @@ components:
         title:
           type: string
           example: "Wrong authentication - You are not authorised to access this resource"
-x-groups:
-  applications:
-    name: "Application"
-    order: 1
+tags:
+  - name: "Application"
     description: Inbound messages to an external account which is linked to an application will be delivered to the application's inbound URL.
-  account:
-    name: "Account"
-    order: 2
+  - name: "Account"
     description: An external-account used as the `from` field in the Messages API and Dispatch API
-  messenger:
-    name: "Facebook Messenger"
-    order: 3
+  - name: "Facebook Messenger"
     description: 'Managing your [Facebook Messenger](https://developer.nexmo.com/messages/concepts/facebook) account'
-  viber_service_msg:
-    name: "Viber Service Message"
-    order: 4
+  - name: "Viber Service Message"
     description: 'Managing your [Viber Service Message](https://developer.nexmo.com/messages/concepts/viber) account'
-  whatsapp:
-    name: "Whatsapp"
-    order: 5
+  - name: "Whatsapp"
     description: 'Managing your [Whatsapp](https://developer.nexmo.com/messages/concepts/whatsapp) account'

--- a/definitions/media.yml
+++ b/definitions/media.yml
@@ -16,7 +16,6 @@ paths:
       summary: List and search media items
       operationId: list-and-search-media-items
       description: Retrieve information about multiple media items with the ability to search and paginate.
-      x-group: media
       parameters:
         - name: order
           description: The order of search results.
@@ -120,7 +119,6 @@ paths:
       summary: Retrieve a media item
       operationId: retrieve-a-media-item
       description: Retrieve information about a single media item
-      x-group: media
       responses:
         '200':
           description: Successfully retrieved
@@ -132,7 +130,6 @@ paths:
       summary: Update a media item
       operationId: update-a-media-item
       description: Update a previously created media item by ID.
-      x-group: media
       requestBody:
         content:
           multipart/form-data:
@@ -174,7 +171,6 @@ paths:
       summary: Delete a media item
       operationId: delete-a-media-item
       description: Delete a previously created media item by ID.
-      x-group: media
       responses:
         '204':
           description: Successfully deleted
@@ -237,11 +233,3 @@ components:
         metadata_secondary:
           type: string
           description: A user set string containing further metadata about the media file.
-x-groups:
-  media:
-    name: "Media"
-    order: 1
-    description: The Media object contains information about the request and details of the media object.
-    schema:
-      application/json:
-        $ref: '#/components/schemas/Media'

--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -19,7 +19,6 @@ paths:
         - basicAuth: []
       summary: Send a Message
       operationId: NewMessage
-      x-group: message
       requestBody:
         description: Send a Message.
         required: true
@@ -525,14 +524,6 @@ components:
           type: string
           description: The name of the location attachment.
           example: 'Nexmo London'
-x-groups:
-  message:
-    name: "Message"
-    order: 1
-    description: The Message object contains information about the request and details of the message object.
-    schema:
-      application/json:
-        $ref: '#/components/schemas/Response'
 
 x-errors:
   1000:

--- a/definitions/number-insight.yml
+++ b/definitions/number-insight.yml
@@ -25,9 +25,6 @@ externalDocs:
 security:
   - apiKey: []
     apiSecret: []
-tags:
-  - name: Request
-    description: 'Ask for information about a phone number'
 paths:
   '/basic/{format}':
     parameters:
@@ -35,9 +32,6 @@ paths:
     get:
       operationId: getNumberInsightBasic
       summary: Basic Number Insight
-      # x-group: number-insight
-      tags:
-        - Request
       parameters:
         - $ref: '#/components/parameters/number'
         - $ref: '#/components/parameters/country'
@@ -57,9 +51,6 @@ paths:
     get:
       operationId: getNumberInsightStandard
       summary: Standard Number Insight
-      # x-group: number-insight
-      tags:
-        - Request
       parameters:
         - $ref: '#/components/parameters/number'
         - $ref: '#/components/parameters/country'
@@ -80,9 +71,6 @@ paths:
     get:
       operationId: getNumberInsightAdvanced
       summary: Advanced Number Insight (sync)
-      # x-group: number-insight
-      tags:
-        - Request
       parameters:
         - $ref: '#/components/parameters/number'
         - $ref: '#/components/parameters/country'
@@ -104,9 +92,6 @@ paths:
     get:
       operationId: getNumberInsightAsync
       summary: Advanced Number Insight (async)
-      # x-group: number-insight
-      tags:
-        - Request
       parameters:
         - $ref: '#/components/parameters/callback'
         - $ref: '#/components/parameters/number'
@@ -1162,13 +1147,3 @@ components:
       name: api_secret
       in: query
       description: 'You can find your API secret in your [account overview](https://dashboard.nexmo.com/account-overview)'
-# x-groups:
-#   number-insight:
-#     name: Number Insight
-#     description: The Number Insight object contains information about the request and details of the phone number information has been requested about.
-#     order: 1
-#     # schema:
-#     #   application/json:
-#     #     $ref: '#/components/schemas/niResponseJsonAdvanced'
-#     #   text/xml:
-#     #     $ref: '#/components/schemas/niResponseXmlAdvanced'

--- a/definitions/redact.yml
+++ b/definitions/redact.yml
@@ -16,7 +16,6 @@ paths:
       summary: Redact a specific message
       operationId: redact-message
       description: ""
-      x-group: transaction
       parameters:
         - name: api_key
           description: Your API key
@@ -79,11 +78,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorThrottled'
-x-groups:
-  transaction:
-    name: Transaction
-    order: 1
-    description: The Redact API can be used to remove personal data from a CDR stored in the Nexmo platform. Personal data held in the platform generally means a person's phone number, and for messages, the body of the message itself.
 
 components:
   securitySchemes:

--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -12,7 +12,6 @@ servers:
 paths:
   /sms/{format}:
     post:
-      x-group: sms
       operationId: send-an-sms
       summary: Send an SMS
       description: Send an outbound SMS from your Nexmo account
@@ -407,16 +406,6 @@ components:
           description: The time when Nexmo started to push this Delivery Receipt to your webhook endpoint.
           type: string
           example: 2020-01-01 12:00:00
-x-groups:
-  sms:
-    name: "SMS"
-    order: 1
-    description: The SMS object contains information about the request and details of the message information.
-    schema:
-      application/json:
-        $ref: '#/components/schemas/SMS'
-      text/xml:
-        $ref: '#/components/schemas/MessageXmlWrapper'
 
 x-errors:
   1:

--- a/definitions/stitch.yml
+++ b/definitions/stitch.yml
@@ -15,7 +15,8 @@ paths:
     post:
       x-swagger-router-controller: createConversation
       operationId: createConversation
-      x-group: conversation
+      tags:
+        - conversation
       summary: Create a conversation
       responses:
         '201':
@@ -25,7 +26,8 @@ paths:
     get:
       x-swagger-router-controller: listConversations
       operationId: listConversations
-      x-group: conversation
+      tags:
+        - conversation
       summary: List conversations
       parameters:
         - $ref: '#/components/parameters/date_start'
@@ -84,7 +86,8 @@ paths:
     put:
       x-swagger-router-controller: conversations
       operationId: replaceConversation
-      x-group: conversation
+      tags:
+        - conversation
       summary: Update a conversation
       responses:
         '200':
@@ -94,7 +97,8 @@ paths:
     get:
       x-swagger-router-controller: retrieveConversation
       operationId: retrieveConversation
-      x-group: conversation
+      tags:
+        - conversation
       summary: Retrieve a conversation
       responses:
         '200':
@@ -147,7 +151,8 @@ paths:
     delete:
       x-swagger-router-controller: deleteConversation
       operationId: deleteConversation
-      x-group: conversation
+      tags:
+        - conversation
       summary: Delete a conversation
       responses:
         '200':
@@ -158,7 +163,8 @@ paths:
     post:
       x-swagger-router-controller: createEvent
       operationId: createEvent
-      x-group: event
+      tags:
+        - event
       summary: Create an event
       requestBody:
         content:
@@ -196,7 +202,8 @@ paths:
     get:
       x-swagger-router-controller: getEvents
       operationId: getEvents
-      x-group: event
+      tags:
+        - event
       summary: List events
       responses:
         '200':
@@ -214,7 +221,8 @@ paths:
     get:
       x-swagger-router-controller: getEvent
       operationId: getEvent
-      x-group: event
+      tags:
+        - event
       summary: Retrieve an event
       responses:
         '200':
@@ -226,7 +234,8 @@ paths:
     delete:
       x-swagger-router-controller: deleteEvent
       operationId: deleteEvent
-      x-group: event
+      tags:
+        - event
       summary: Delete an event
       responses:
         '200':
@@ -237,7 +246,8 @@ paths:
     get:
       x-swagger-router-controller: members
       operationId: getMembers
-      x-group: member
+      tags:
+        - member
       summary: List members
       responses:
         '200':
@@ -265,7 +275,8 @@ paths:
     post:
       x-swagger-router-controller: members
       operationId: createMember
-      x-group: member
+      tags:
+        - member
       summary: Create a member
       responses:
         '201':
@@ -315,7 +326,8 @@ paths:
     get:
       x-swagger-router-controller: members
       operationId: getMember
-      x-group: member
+      tags:
+        - member
       summary: Retrieve a member
       responses:
         '200':
@@ -331,7 +343,8 @@ paths:
     put:
       x-swagger-router-controller: members
       operationId: updateMember
-      x-group: member
+      tags:
+        - member
       summary: Update a member
       responses:
         '200':
@@ -356,7 +369,8 @@ paths:
     delete:
       x-swagger-router-controller: members
       operationId: deleteMember
-      x-group: member
+      tags:
+        - member
       summary: Delete a member
       responses:
         '200':
@@ -365,7 +379,8 @@ paths:
     get:
       x-swagger-router-controller: users
       operationId: getUsers
-      x-group: user
+      tags:
+        - user
       summary: List users
       responses:
         '200':
@@ -386,7 +401,8 @@ paths:
     post:
       x-swagger-router-controller: users
       operationId: createUser
-      x-group: user
+      tags:
+        - user
       summary: Create a user
       responses:
         '200':
@@ -421,7 +437,8 @@ paths:
     get:
       x-swagger-router-controller: users
       operationId: getUser
-      x-group: user
+      tags:
+        - user
       summary: Retrieve a user
       responses:
         '200':
@@ -437,7 +454,8 @@ paths:
     put:
       x-swagger-router-controller: users
       operationId: updateUser
-      x-group: user
+      tags:
+        - user
       summary: Update a user
       responses:
         '200':
@@ -466,7 +484,8 @@ paths:
     delete:
       x-swagger-router-controller: users
       operationId: deleteUser
-      x-group: user
+      tags:
+        - user
       summary: Delete a user
       responses:
         '200':
@@ -477,7 +496,8 @@ paths:
     get:
       x-swagger-router-controller: users
       operationId: getuserConversations
-      x-group: user
+      tags:
+        - user
       summary: List user conversations
       responses:
         '200':
@@ -514,7 +534,8 @@ paths:
     get:
       x-swagger-router-controller: listLegs
       operationId: listLegs
-      x-group: leg
+      tags:
+        - leg
       summary: List legs
       responses:
         '200':
@@ -617,7 +638,8 @@ paths:
     delete:
       x-swagger-router-controller: deleteLeg
       operationId: deleteLeg
-      x-group: leg
+      tags:
+        - leg
       summary: Delete a leg
       responses:
         '200':
@@ -1080,28 +1102,17 @@ components:
       bearerFormat: JWT
 security:
   - bearerAuth: []
-x-groups:
-  conversation:
-    name: Conversation
-    order: 1
+
+tags:
+  - name: Conversation
     description: A conversation is a shared core component that Nexmo APIs rely on. Conversations happen over multiple mediums and and can have associated Users through Memberships.
-  user:
-    name: User
-    order: 2
+  - name: User
     description: 'The concept of a user exists in Nexmo APIs, you can associate one with a user in your own application if you choose. A user can have multiple memberships to conversations and can communicate with other users through various different mediums.'
-  member:
-    name: Member
-    order: 3
+  - name: Member
     description: Memberships connect users with conversations. Each membership has one conversation and one user however a user can have many memberships to conversations just as conversations can have many members.
-  event:
-    name: Event
-    order: 4
+  - name: Event
     description: 'Events are actions that occur within a conversation. Examples of this includes: Text events from members, or invite events from users'
-  leg:
-    name: Leg
-    order: 5
+  - name: Leg
     description: 'A leg can be a video call, IP call, or PSTN call that users participate in using multiple platforms. With this endpoint you can retrieve the details about all of the legs that took place in your application.'
-  rtc:
-    name: Rtc
-    order: 6
+  - name: Rtc
     description: Rtc actions. Any rtc action related (like starting a new rtc connection).

--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -19,7 +19,6 @@ paths:
       summary: Create an outbound call
       description: Create an outbound Call
       operationId: createCall
-      x-group: calls
       requestBody:
         description: Call Details
         content:
@@ -116,7 +115,6 @@ paths:
       summary: Get details of your calls
       description: Get details of your calls
       operationId: getCalls
-      x-group: calls
       parameters:
       - name: status
         in: query
@@ -269,7 +267,6 @@ paths:
       summary: Get detail of a specific call
       description: Get detail of a specific call
       operationId: getCall
-      x-group: call
       responses:
         '200':
           description: Ok
@@ -318,7 +315,6 @@ paths:
       summary: Modify an in progress call
       description: Modify an in progress call
       operationId: updateCall
-      x-group: call
       requestBody:
         required: true
         content:
@@ -370,7 +366,6 @@ paths:
       summary: Play an audio file into a call
       description: Play an audio file into a call
       operationId: startStream
-      x-group: stream
       requestBody:
         description: action to perform
         required: true
@@ -416,7 +411,6 @@ paths:
       summary: Stop playing an audio file into a call
       description: Stop playing an audio file into a call
       operationId: stopStream
-      x-group: stream
       responses:
         '200':
           description: Ok
@@ -446,7 +440,6 @@ paths:
       summary: Play text to speech into a call
       description: Play text to speech into a call
       operationId: startTalk
-      x-group: talk
       requestBody:
         description: Action to perform
         content:
@@ -491,7 +484,6 @@ paths:
       summary: Stop text to speech in a call
       description: Stop text to speech in a call
       operationId: stopTalk
-      x-group: talk
       responses:
         '200':
           description: Ok
@@ -521,7 +513,6 @@ paths:
       summary: Play DTMF tones into a call
       description: Play DTMF tones into a call
       operationId: startDTMF
-      x-group: dtmf
       requestBody:
         description: action to perform
         required: true
@@ -829,24 +820,3 @@ components:
       - Filiz
       - Mizuki
       - Seoyeon
-x-groups:
-  calls:
-    name: Calls
-    order: 1
-    description: Create and search calls
-  call:
-    name: Call
-    order: 2
-    description: Manage a specific call
-  stream:
-    name: Stream
-    order: 3
-    description: Stream audio to an active call
-  talk:
-    name: Talk
-    order: 4
-    description: Send a synthesized speech message to an active call
-  dtmf:
-    name: DTMF
-    order: 5
-    description: Send Dual-tone multi-frequency (DTMF) tones to an active call


### PR DESCRIPTION
We're updating our rendering to no longer use x-groups but instead use tags from the OpenAPI standard. This PR removes x-groups from our existing specs, and converts them to tags where that seems useful.