### PR TITLE
Read callback deprecated for Viber

### DIFF
--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -155,7 +155,7 @@ components:
         status:
           type: string
           example: delivered
-          description: The status of the message. The `read` message status is only available for `viber_service_msg` and `messenger`.
+          description: The status of the message. The `read` message status is only available for `messenger`.
           enum:
             - submitted
             - delivered


### PR DESCRIPTION
## Description 

Read callback was deprecated on 19th Dec 2018 by Viber to reduce load.