### PR TITLE
Change default value of next_event_wait

### DIFF
--- a/definitions/verify.yml
+++ b/definitions/verify.yml
@@ -237,12 +237,12 @@ paths:
           in: query
           description: >-
             Specifies the wait time in seconds between attempts to deliver the
-            verification code. Verify calculates the default value based on the average time
-            taken by users to complete verification.
+            verification code. 
           schema:
             type: integer
             minimum: 60
             maximum: 900
+            default: 300
           example: 300
       responses:
         '200':


### PR DESCRIPTION
According to Aurelian Favre, the docs that state that `next_event_wait` is autosized are wrong, despite the following KB article: https://help.nexmo.com/hc/en-us/articles/203824206. The default is `300`.