### PR TITLE
Fix link to delivery receipt error status docs

### DIFF
--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: 1.0.0
+  version: 1.0.1
   title: SMS API
   description: With the Nexmo SMS API you can send SMS from your account and lookup messages both messages that you've sent as well as messages sent to your virtual numbers. Numbers are specified in E.164 format.
   contact:
@@ -400,7 +400,7 @@ components:
           example: '2001011400'
         err-code:
           type: string
-          description: The status of the request. Will be a non `0` value if there has been an error. See the [SMS error reference](https://developer.nexmo.com/api-errors/sms) for more details
+          description: The status of the request. Will be a non `0` value if there has been an error. See the [Delivery Receipt documentation](https://developer.nexmo.com/messaging/sms/guides/delivery-receipts#dlr-error-codes) for more details
           example: '0'
         message-timestamp:
           description: The time when Nexmo started to push this Delivery Receipt to your webhook endpoint.


### PR DESCRIPTION
# Description

Sam pointed out that we are linking to SMS error codes from a delivery receipt status context. This pull request corrects the link.

# Checklist

- [x] version number incremented (in the `info` section of the spec)
