### PR TITLE
Mention that POST requests are also accepted

### DIFF
--- a/definitions/number-insight.yml
+++ b/definitions/number-insight.yml
@@ -28,6 +28,10 @@ paths:
     get:
       operationId: getNumberInsightBasic
       summary: Basic Number Insight
+      description: |
+        Provides [basic number insight](/number-insight/overview#basic-standard-and-advanced-apis) information about a number.
+
+        Note that this endpoint also supports [POST] requests.
       parameters:
         - $ref: '#/components/parameters/number'
         - $ref: '#/components/parameters/country'
@@ -47,6 +51,10 @@ paths:
     get:
       operationId: getNumberInsightStandard
       summary: Standard Number Insight
+      description: |
+        Provides [standard number insight](/number-insight/overview#basic-standard-and-advanced-apis) information about a number.
+
+        Note that this endpoint also supports [POST] requests.      
       parameters:
         - $ref: '#/components/parameters/number'
         - $ref: '#/components/parameters/country'
@@ -67,6 +75,10 @@ paths:
     get:
       operationId: getNumberInsightAdvanced
       summary: Advanced Number Insight (sync)
+      description: |
+        Provides [advanced number insight](/number-insight/overview#basic-standard-and-advanced-apis) information about a number synchronously, in the same way that the basic and standard endpoints do.
+
+        Note that this endpoint also supports [POST] requests.
       parameters:
         - $ref: '#/components/parameters/number'
         - $ref: '#/components/parameters/country'
@@ -88,6 +100,10 @@ paths:
     get:
       operationId: getNumberInsightAsync
       summary: Advanced Number Insight (async)
+      description: |
+        Provides [advanced number insight](/number-insight/overview#basic-standard-and-advanced-apis) number information **asynchronously** using the URL specified in the `callback` parameter.
+
+        Note that this endpoint also supports [POST] requests.
       parameters:
         - $ref: '#/components/parameters/callback'
         - $ref: '#/components/parameters/number'

--- a/definitions/number-insight.yml
+++ b/definitions/number-insight.yml
@@ -4,7 +4,7 @@ servers:
   - url: 'https://api.nexmo.com/ni'
 info:
   title: Number Insight API
-  version: 1.0.0
+  version: 1.0.1
   description: >-
     Nexmo's Number Insight API delivers real-time intelligence about the validity, reachability and roaming status of a phone number and tells you how to format the number correctly in your application. There are three levels of Number Insight API available: [Basic, Standard and Advanced](/number-insight/overview#basic-standard-and-advanced-apis). The advanced API is available asynchronously as well as synchronously.
   contact:
@@ -31,7 +31,7 @@ paths:
       description: |
         Provides [basic number insight](/number-insight/overview#basic-standard-and-advanced-apis) information about a number.
 
-        Note that this endpoint also supports [POST] requests.
+        Note that this endpoint also supports `POST` requests.
       parameters:
         - $ref: '#/components/parameters/number'
         - $ref: '#/components/parameters/country'
@@ -54,7 +54,7 @@ paths:
       description: |
         Provides [standard number insight](/number-insight/overview#basic-standard-and-advanced-apis) information about a number.
 
-        Note that this endpoint also supports [POST] requests.      
+        Note that this endpoint also supports `POST` requests.      
       parameters:
         - $ref: '#/components/parameters/number'
         - $ref: '#/components/parameters/country'
@@ -78,7 +78,7 @@ paths:
       description: |
         Provides [advanced number insight](/number-insight/overview#basic-standard-and-advanced-apis) information about a number synchronously, in the same way that the basic and standard endpoints do.
 
-        Note that this endpoint also supports [POST] requests.
+        Note that this endpoint also supports `POST` requests.
       parameters:
         - $ref: '#/components/parameters/number'
         - $ref: '#/components/parameters/country'
@@ -103,7 +103,7 @@ paths:
       description: |
         Provides [advanced number insight](/number-insight/overview#basic-standard-and-advanced-apis) number information **asynchronously** using the URL specified in the `callback` parameter.
 
-        Note that this endpoint also supports [POST] requests.
+        Note that this endpoint also supports `POST` requests.
       parameters:
         - $ref: '#/components/parameters/callback'
         - $ref: '#/components/parameters/number'


### PR DESCRIPTION
# Description

The Number Insight APIs accept `POST` as well as `GET` requests. We don't want to advertise this (the NI API is read-only, making `GET` the most appropriate verb for requests) but we do need to document it.

