### PR TITLE
Add ability to specify a single definition to ./bin/validate-specs.sh

### DIFF
--- a/bin/validate-specs.sh
+++ b/bin/validate-specs.sh
@@ -13,7 +13,13 @@ COMMAND="$COMMAND -s openapi-tags-alphabetical"
 # There's an issue that means file-based refs trigger this rule incorrectly
 COMMAND="$COMMAND -s reference-no-other-properties"
 
-for i in $(ls definitions/*.yml); do
+DOCS=$1
+
+if [[ -z "$DOCS" ]]; then
+  DOCS=$(ls definitions/*.yml)
+fi
+
+for i in $DOCS; do
   echo -n "$i "
 
   OUTPUT=$($COMMAND $i 2>&1)


### PR DESCRIPTION
# Description

When working on a PR locally running `./bin/validate-specs.sh` checks every OAS doc (even ones that you're not working on).

This PR allows you to specify a definition e.g. `./bin/validate-specs.sh definitions/voice.yml`

# Checklist

N/A