### PR TITLE
Add missing Number OAS params and responses

### DIFF
--- a/definitions/numbers.yml
+++ b/definitions/numbers.yml
@@ -28,10 +28,9 @@ paths:
       operationId: getOwnedNumbers
       summary: List the numbers you own
       description: Retrieve all the inbound numbers associated with your Nexmo account.
-      security:
-      - apiKeyPath: []
-        apiSecretPath: []
       parameters:
+        - $ref: '#/components/parameters/apiKeyPath'
+        - $ref: '#/components/parameters/apiSecretPath'             
         - $ref: '#/components/parameters/index'
         - $ref: '#/components/parameters/size'
         - $ref: '#/components/parameters/pattern'
@@ -237,19 +236,6 @@ paths:
         '401':
           description: Unauthorized
 components:
-  securitySchemes:
-    apiKeyPath:
-      type: apiKey
-      name: api_key
-      in: path
-      description: >-
-        You can find your API key in the [developer dashboard](https://dashboard.nexmo.com)
-    apiSecretPath:
-      type: apiKey
-      name: api_secret
-      in: path
-      description: >-
-        You can find your API secret in the [developer dashboard](https://dashboard.nexmo.com)
   parameters:
     apiKey:
       type: apiKey
@@ -264,7 +250,19 @@ components:
       in: query
       required: true
       description: >-
-        You can find your API secret in the [developer dashboard](https://dashboard.nexmo.com)  
+        You can find your API secret in the [developer dashboard](https://dashboard.nexmo.com)
+    apiKeyPath:
+      type: apiKey
+      name: api_key
+      in: path
+      description: >-
+        You can find your API key in the [developer dashboard](https://dashboard.nexmo.com)
+    apiSecretPath:
+      type: apiKey
+      name: api_secret
+      in: path
+      description: >-
+        You can find your API secret in the [developer dashboard](https://dashboard.nexmo.com)        
     index:
       name: index
       required: false

--- a/definitions/numbers.yml
+++ b/definitions/numbers.yml
@@ -26,11 +26,14 @@ security:
   - apiKey: []
     apiSecret: []
 paths:
-  '/account/numbers':
+  '/account/numbers/{api_key}/{api_secret}':
     get:
       operationId: getOwnedNumbers
       summary: List the numbers you own
       description: Retrieve all the inbound numbers associated with your Nexmo account.
+      security:
+      - apiKeyPath: []
+        apiSecretPath: []
       parameters:
         - $ref: '#/components/parameters/index'
         - $ref: '#/components/parameters/size'

--- a/definitions/numbers.yml
+++ b/definitions/numbers.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Numbers API
-  version: 1.0.2
+  version: 1.0.3
   description: >-
     The Numbers API enables you to manage your existing numbers and buy new virtual numbers for
     use with Nexmo's APIs.

--- a/definitions/numbers.yml
+++ b/definitions/numbers.yml
@@ -22,9 +22,6 @@ servers:
 externalDocs:
   url: 'https://developer.nexmo.com/api/developer/numbers'
   x-sha1: 8ad8bc6b0c51af4ca458c13cfced6124783ab113
-security:
-  - apiKey: []
-    apiSecret: []
 paths:
   '/account/numbers/{api_key}/{api_secret}':
     get:
@@ -57,7 +54,10 @@ paths:
       summary: Search available numbers
       description: Retrieve inbound numbers that are available for    the specified country.
       parameters:
+        - $ref: '#/components/parameters/apiKey'
+        - $ref: '#/components/parameters/apiSecret'        
         - $ref: '#/components/parameters/country'
+        - $ref: '#/components/parameters/type'        
         - $ref: '#/components/parameters/pattern'
         - $ref: '#/components/parameters/search_pattern'
         - name: features
@@ -93,6 +93,8 @@ paths:
       summary: Buy a number
       description: Request to purchase a specific inbound number.
       parameters:
+        - $ref: '#/components/parameters/apiKey'
+        - $ref: '#/components/parameters/apiSecret'        
         - $ref: '#/components/parameters/country'
         - name: msisdn
           required: true
@@ -113,12 +115,14 @@ paths:
                 $ref: '#/components/schemas/response'
         '401':
           description: Unauthorized
-  '/number/cancel':
+  '/number/cancel':  
     post:
       operationId: cancelANumber
       summary: Cancel a number
       description: Cancel your subscription for a specific inbound number.
       parameters:
+        - $ref: '#/components/parameters/apiKey'
+        - $ref: '#/components/parameters/apiSecret'        
         - $ref: '#/components/parameters/country'
         - name: msisdn
           required: true
@@ -145,6 +149,8 @@ paths:
       summary: Update a number
       description: Change the behaviour of a number that you own.
       parameters:
+        - $ref: '#/components/parameters/apiKey'
+        - $ref: '#/components/parameters/apiSecret'        
         - $ref: '#/components/parameters/country'
         - name: msisdn
           required: true
@@ -171,10 +177,30 @@ paths:
           schema:
             type: string
           example: inbound
+        - name: messagesCallbackType
+          required: false
+          in: query
+          description: The SMS webhook type (always `app`). Must be used
+            with the `messagesCallbackValue` parameter.
+          schema:
+            type: string
+            enum:
+              - app
+          example: app
+        - name: messagesCallbackValue
+          required: false
+          in: query
+          description: >-
+            A Nexmo Application ID. Must be used
+            with the `messagesCallbackType` parameter.
+          schema:
+            type: string
+          example: 'aaaaaaaa-bbbb-cccc-dddd-0123456789ab'          
         - name: voiceCallbackType
           required: false
           in: query
-          description: The voice webhook type
+          description: The voice webhook type. Must be used
+            with the `voiceCallbackValue` parameter.
           schema:
             type: string
             enum:
@@ -212,19 +238,33 @@ paths:
           description: Unauthorized
 components:
   securitySchemes:
+    apiKeyPath:
+      type: apiKey
+      name: api_key
+      in: path
+      description: >-
+        You can find your API key in the [developer dashboard](https://dashboard.nexmo.com)
+    apiSecretPath:
+      type: apiKey
+      name: api_secret
+      in: path
+      description: >-
+        You can find your API secret in the [developer dashboard](https://dashboard.nexmo.com)
+  parameters:
     apiKey:
       type: apiKey
       name: api_key
       in: query
+      required: true
       description: >-
         You can find your API key in the [developer dashboard](https://dashboard.nexmo.com)
     apiSecret:
       type: apiKey
       name: api_secret
       in: query
+      required: true
       description: >-
-        You can find your API secret in the [developer dashboard](https://dashboard.nexmo.com)
-  parameters:
+        You can find your API secret in the [developer dashboard](https://dashboard.nexmo.com)  
     index:
       name: index
       required: false
@@ -279,6 +319,18 @@ components:
       schema:
         type: string
       example: GB
+    type:
+      name: type
+      in: query
+      required: false
+      description: Set this parameter to filter the type of number, such as mobile or landline
+      schema:
+        type: string
+        enum:
+          - landline
+          - mobile-lvn
+          - landline-toll-free
+      example: mobile-lvn      
   schemas:
     number:
       type: object
@@ -307,6 +359,14 @@ components:
             type: string
           example: [VOICE, SMS]
           description: 'The capabilities of the number: `SMS` or `VOICE` or `SMS,VOICE`'
+        messagesCallbackType:
+          type: string
+          example: app
+          description: 'The messages webhook type: always `app`'
+        messagesCallbackValue:
+          type: string
+          example: aaaaaaaa-bbbb-cccc-dddd-0123456789ab
+          description: A Nexmo Application ID         
         voiceCallbackType:
           type: string
           example: app

--- a/definitions/numbers.yml
+++ b/definitions/numbers.yml
@@ -23,7 +23,7 @@ externalDocs:
   url: 'https://developer.nexmo.com/api/developer/numbers'
   x-sha1: 8ad8bc6b0c51af4ca458c13cfced6124783ab113
 paths:
-  '/account/numbers/{api_key}/{api_secret}':
+  '/account/numbers/{NEXMO_API_KEY}/{NEXMO_API_SECRET}':
     get:
       operationId: getOwnedNumbers
       summary: List the numbers you own
@@ -238,31 +238,41 @@ paths:
 components:
   parameters:
     apiKey:
-      type: apiKey
       name: api_key
       in: query
       required: true
       description: >-
         You can find your API key in the [developer dashboard](https://dashboard.nexmo.com)
+      schema:
+        type: string
+      example: 1a23b45c        
     apiSecret:
-      type: apiKey
       name: api_secret
       in: query
       required: true
       description: >-
         You can find your API secret in the [developer dashboard](https://dashboard.nexmo.com)
+      schema:
+        type: string
+      example: Ab1CDEfghIJ23k4          
     apiKeyPath:
-      type: apiKey
-      name: api_key
+      name: NEXMO_API_KEY
       in: path
+      required: true
       description: >-
         You can find your API key in the [developer dashboard](https://dashboard.nexmo.com)
+      schema:
+        type: string
+      example: 1a23b45c         
     apiSecretPath:
-      type: apiKey
-      name: api_secret
+      name: NEXMO_API_SECRET
       in: path
+      required: true
       description: >-
-        You can find your API secret in the [developer dashboard](https://dashboard.nexmo.com)        
+        You can find your API secret in the [developer dashboard](https://dashboard.nexmo.com)  
+      schema:
+        type: string
+      example: Ab1CDEfghIJ23k4                 
     index:
       name: index
       required: false


### PR DESCRIPTION
# Description

Address editorial comments on main NDP PR: https://github.com/Nexmo/nexmo-developer/pull/1616

- Move API key and secret to path for "list owned numbers" endpoint
- Add missing `messagesCallbackType` / `messagesCallbackValue` params for "update" endpoint and responses for the "list" endpoint
- Add `type` param for "search" endpoint

# Checklist

- [X] version number incremented (in the `info` section of the spec)
