### PR TITLE
Add API error descriptions for account + application.v2

### DIFF
--- a/definitions/account.yml
+++ b/definitions/account.yml
@@ -597,3 +597,21 @@ components:
                 type: string
                 description: Internal Trace ID
                 example: bf0ca0bf927b3b52e3cb03217e1a1ddf
+
+x-errors:
+  validation:
+    description: The provided payload is invalid
+    resolution: |
+        Modify your request to provide a valid payload.
+        * Minimum 8 characters
+        * Maximum 25 characters
+        * Minimum 1 lower case character
+        * Minimum 1 upper case character
+        * Minimum 1 digit
+    link:
+      text: View API reference
+      url: /api/account/api-secret-management#createSecret
+
+  delete-last-secret:
+    description: You can not delete your only API secret
+    resolution: Add another API secret before deleting this one

--- a/definitions/application.v2.yml
+++ b/definitions/application.v2.yml
@@ -640,4 +640,23 @@ components:
                           example: POST
             vbc:
               type: object
-              description: "Specify the `vbc` capability to enable zero-rated calls for VBC number programmability service applications. This is always an empty object."                         
+              description: "Specify the `vbc` capability to enable zero-rated calls for VBC number programmability service applications. This is always an empty object."
+
+x-errors:
+  payload-validation:
+    description: Invalid request. See `invalid_parameters` field for details
+    resolution: Review the documentation and send a valid `POST` request.
+    link:
+      text: View API reference
+      url: /api/application.v2#createApplication
+
+  list-validation:
+    description: Invalid request. See `invalid_parameters` field for details
+    resolution: Review the documentation and send a valid `GET` request.
+    link:
+      text: View API reference
+      url: /api/application.v2#listApplication
+
+  rate-limit:
+    description: The request was rate limited
+    resolution: The Redact API supports 170 requests per second. Reduce the frequency of your requests.


### PR DESCRIPTION
# Description

Adds error definitions for the `/api-errors` page on NDP that we are currently returning in the API but don't lead anywhere when clicked.

# Checklist

- [ ] version number incremented (in the `info` section of the spec) - No API changes, just errors
