### PR TITLE
The URI in the 'to' of a call needs sip: prefix

### DIFF
--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -737,7 +737,7 @@ components:
       type: string
       minLength: 1
       maxLength: 50
-      example: rebekka@sip.example.com
+      example: sip:rebekka@sip.example.com
     AddressWebsocket:
       type: string
       minLength: 1


### PR DESCRIPTION
Otherwise an error will be returned.

# Description

When trying to route a call to a SIP URI I followed the documentation and omitted the `sip:` prefix in the URI, e.g.:

```
   "to":[{
       "type": "sip",
       "uri": "7777777@voip.tnltd.net"
   }],
```
and got an error back:
```
{"type":400,"title":"Bad Request","invalid_parameters":[{"reason":"invalid sip uri","name":"uri"}]}
```

The URI must be a full SIP URI with `sip:` prefix.

(This is from an NPE; I'm assuming the same applies to Production)

# Checklist

- [ ] version number incremented (in the `info` section of the spec)
