### PR TITLE
Add links to NDP docs from API references

### DIFF
--- a/definitions/audit.yml
+++ b/definitions/audit.yml
@@ -1,10 +1,12 @@
 openapi: "3.0.0"
 
 info:
-  version: 1.0.0
+  version: 1.0.1
   title: Nexmo Audit API
   description: >
-    Nexmo's Audit API allows you to view details of changes to your account.
+    Nexmo's Audit API allows you to view details of changes to your account. More information is available at <https://developer.nexmo.com/audit/overview>.
+
+    _Please note that the Audit API is currently in Beta_
   contact:
     name: Nexmo DevRel
     email: devrel@nexmo.com

--- a/definitions/number-insight.yml
+++ b/definitions/number-insight.yml
@@ -4,9 +4,9 @@ servers:
   - url: 'https://api.nexmo.com/ni'
 info:
   title: Number Insight API
-  version: 1.0.1
+  version: 1.0.2
   description: >-
-    Nexmo's Number Insight API delivers real-time intelligence about the validity, reachability and roaming status of a phone number and tells you how to format the number correctly in your application. There are three levels of Number Insight API available: [Basic, Standard and Advanced](/number-insight/overview#basic-standard-and-advanced-apis). The advanced API is available asynchronously as well as synchronously.
+    Nexmo's Number Insight API delivers real-time intelligence about the validity, reachability and roaming status of a phone number and tells you how to format the number correctly in your application. There are three levels of Number Insight API available: [Basic, Standard and Advanced](https://developer.nexmo.com/number-insight/overview#basic-standard-and-advanced-apis). The advanced API is available asynchronously as well as synchronously.
   contact:
     name: Nexmo DevRel
     email: devrel@nexmo.com

--- a/definitions/numbers.yml
+++ b/definitions/numbers.yml
@@ -1,10 +1,10 @@
 openapi: 3.0.0
 info:
   title: Numbers API
-  version: 1.0.5
+  version: 1.0.6
   description: >-
     The Numbers API enables you to manage your existing numbers and buy new virtual numbers for
-    use with Nexmo's APIs.
+    use with Nexmo's APIs. Further information is here: <https://developer.nexmo.com/numbers/overview>
   contact:
     name: Nexmo.com
     email: devrel@nexmo.com
@@ -20,8 +20,8 @@ info:
 servers:
   - url: 'https://rest.nexmo.com'
 externalDocs:
-  url: 'https://developer.nexmo.com/api/developer/numbers'
-  x-sha1: 8ad8bc6b0c51af4ca458c13cfced6124783ab113
+  description: Numbers product documentation on the Nexmo Developer Portal
+  url: 'https://developer.nexmo.com/numbers/overview'
 security:
   - apiKey: []
     apiSecret: []  

--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -1,8 +1,8 @@
 openapi: "3.0.0"
 info:
-  version: 1.0.2
+  version: 1.0.3
   title: SMS API
-  description: With the Nexmo SMS API you can send SMS from your account and lookup messages both messages that you've sent as well as messages sent to your virtual numbers. Numbers are specified in E.164 format.
+  description: With the Nexmo SMS API you can send SMS from your account and lookup messages both messages that you've sent as well as messages sent to your virtual numbers. Numbers are specified in E.164 format. More SMS API documentation is at <https://developer.nexmo.com/messaging/sms/overview>
   contact:
     name: Nexmo DevRel
     email: devrel@nexmo.com

--- a/definitions/verify.yml
+++ b/definitions/verify.yml
@@ -3,7 +3,7 @@ servers:
   - url: 'https://api.nexmo.com/verify'
 info:
   title: Nexmo Verify API
-  version: 1.0.1
+  version: 1.0.2
   description: >-
     The Verify API helps you to implement 2FA (two-factor authentication) in your applications.
     This is useful for:
@@ -14,6 +14,8 @@ info:
     * Monitoring suspicious activity, by forcing an account user to verify ownership of a number
 
     * Ensuring that you can reach your users at any time because you have their correct phone number
+
+    More information is available at <https://developer.nexmo.com/verify>
   contact:
     name: Nexmo DevRel
     email: devrel@nexmo.com
@@ -23,7 +25,8 @@ info:
     name: The MIT License (MIT)
     url: 'https://opensource.org/licenses/MIT'
 externalDocs:
-  url: 'https://developer.nexmo.com/api/verify'
+  description: "More information on the Verify product on our Developer Portal"
+  url: 'https://developer.nexmo.com/verify'
 security:
   - apiKey: []
     apiSecret: []

--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -1,10 +1,11 @@
 ---
 openapi: 3.0.0
 info:
-  version: 1.0.1
+  version: 1.0.2
   title: Voice API
   description: The Voice API lets you create outboud calls, control in progress calls
-    and get information about historical calls.
+    and get information about historical calls. More information about the Voice API
+    can be found at <https://developer.nexmo.com/voice/voice-api/overview>.
   contact:
     name: Nexmo DevRel
     email: devrel@nexmo.com


### PR DESCRIPTION
# Description

When viewing an API reference doc on https://developer.nexmo.com, we don't have a link to get "back" to the main documentation that this API relates to. This adds documentation links for our stable APIs, and updates `externalDocs` fields where appropriate.

# Checklist

- [x] version number incremented (in the `info` section of the spec)

^ yes, in all of them!