### PR TITLE
Add fallback_answer_url for Applications V2

### DIFF
--- a/definitions/application.v2.yml
+++ b/definitions/application.v2.yml
@@ -1,7 +1,7 @@
 ---
 openapi: "3.0.0"
 info:
-  version: 1.0.2
+  version: 1.0.3
   title: "Application API"
   description: |
     This is the *beta* version of the Application API.
@@ -71,6 +71,22 @@ paths:
                                 address:
                                   type: string
                                   example: https://example.com/webhooks/answer
+                                http_method:
+                                  type: string
+                                  example: GET
+                                  enum:
+                                    - GET
+                                    - POST
+                            fallback_answer_url:
+                              type: object
+                              description: |
+                                  If your `answer_url` is offline or returns a HTTP error code, Nexmo will make a request to a
+                                  `fallback_answer_url` if it is set. This URL must return an NCCO.
+                              x-nexmo-developer-collection-description-shown: true
+                              properties:
+                                address:
+                                  type: string
+                                  example: https://fallback.example.com/webhooks/answer
                                 http_method:
                                   type: string
                                   example: GET
@@ -367,6 +383,23 @@ paths:
                                   enum:
                                     - GET
                                     - POST
+                            fallback_answer_url:
+                              type: object
+                              description: |
+                                  If your `answer_url` is offline or returns a HTTP error code, Nexmo will make a request to a
+                                  `fallback_answer_url` if it is set. This URL must return an NCCO
+                              x-nexmo-developer-collection-description-shown: true
+                              properties:
+                                address:
+                                  type: string
+                                  example: https://fallback.example.com/webhooks/answer
+                                http_method:
+                                  type: string
+                                  example: GET
+                                  enum:
+                                    - GET
+                                    - POST
+ 
                             event_url:
                               type: object
                               description: "Nexmo will send call events (e.g. `ringing`, `answered`) to this URL"
@@ -571,6 +604,19 @@ components:
                           type: string
                           example: https://example.com/webhooks/answer
                           description: The URL that Nexmo requests when a call is placed/received. Must return an NCCO
+                        http_method:
+                          type: string
+                          example: POST
+                          description: The HTTP method used to fetch your NCCO from your `answer_url`
+                    fallback_answer_url:
+                      type: object
+                      properties:
+                        address:
+                          type: string
+                          example: https://fallback.example.com/webhooks/answer
+                          description: |
+                                  If your `answer_url` is offline or returns a HTTP error code, Nexmo will make a request to a
+                                  `fallback_answer_url` if it is set. This URL must return an NCCO.
                         http_method:
                           type: string
                           example: POST


### PR DESCRIPTION
# Description

If a user's main answer_url is offline or returns a HTTP error, we want to
request an NCCO from a fallback URL.

**NOTE:** This should only be merged once the functionality is in production

# Checklist

- [x] version number incremented (in the `info` section of the spec)
