### PR TITLE
Fix API secret description

### DIFF
--- a/definitions/numbers.yml
+++ b/definitions/numbers.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Numbers API
-  version: 1.0.6
+  version: 1.0.7
   description: >-
     The Numbers API enables you to manage your existing numbers and buy new virtual numbers for
     use with Nexmo's APIs. Further information is here: <https://developer.nexmo.com/numbers/overview>

--- a/definitions/numbers.yml
+++ b/definitions/numbers.yml
@@ -168,7 +168,7 @@ components:
       type: apiKey
       name: api_secret
       in: query
-      description: 'You can find your API key in the [developer dashboard](https://dashboard.nexmo.com)'
+      description: 'You can find your API secret in the [developer dashboard](https://dashboard.nexmo.com)'
   parameters:                     
     index:
       name: index


### PR DESCRIPTION
# Description

The `api_secret` description incorrectly referred to the key, rather than the secret.

# Checklist

- [X] version number incremented (in the `info` section of the spec)
