### PR TITLE
Speccy validation should check OAS definitions in subdirectories

### DIFF
--- a/bin/validate-specs.sh
+++ b/bin/validate-specs.sh
@@ -16,7 +16,7 @@ COMMAND="$COMMAND -s reference-no-other-properties"
 DOCS=$1
 
 if [[ -z "$DOCS" ]]; then
-  DOCS=$(find definitions -name '*.yml')
+  DOCS=$(find definitions -name '*.yml' -not -path "*definitions/common*")
 fi
 
 for i in $DOCS; do

--- a/bin/validate-specs.sh
+++ b/bin/validate-specs.sh
@@ -16,7 +16,7 @@ COMMAND="$COMMAND -s reference-no-other-properties"
 DOCS=$1
 
 if [[ -z "$DOCS" ]]; then
-  DOCS=$(ls definitions/*.yml)
+  DOCS=$(find definitions -name '*.yml')
 fi
 
 for i in $DOCS; do


### PR DESCRIPTION
# Description

Currently, `/bin/validate-specs.sh` only validates YML files in the `/definitions` directory when no validation directory is passed as a parameter. Because `/definitions` now has subdirectories (e.g. `vonage-business-cloud` and `account`), this change finds all files within those subdirectories and runs `speccy` against them too.

