### PR TITLE
Fix incomplete description in NI Advanced Async callback

### DIFF
--- a/definitions/number-insight.yml
+++ b/definitions/number-insight.yml
@@ -101,7 +101,7 @@ paths:
             post:
               operationId: asyncCallback
               summary: Asynchronous response
-              description: Contains the response to your
+              description: Contains the response to your Number Insight Advanced API request.
               requestBody:
                 content:
                   application/json:

--- a/definitions/number-insight.yml
+++ b/definitions/number-insight.yml
@@ -4,7 +4,7 @@ servers:
   - url: 'https://api.nexmo.com/ni'
 info:
   title: Number Insight API
-  version: 1.0.3
+  version: 1.0.4
   description: >-
     Nexmo's Number Insight API delivers real-time intelligence about the validity, reachability and roaming status of a phone number and tells you how to format the number correctly in your application. There are three levels of Number Insight API available: [Basic, Standard and Advanced](https://developer.nexmo.com/number-insight/overview#basic-standard-and-advanced-apis). The advanced API is available asynchronously as well as synchronously.
   contact:


### PR DESCRIPTION
# Description

The `description` field for the NI Advanced API async response is incomplete. It says "Contains the response to your". (Your what?). Completed the sentence.

# Checklist

- [X] version number incremented (in the `info` section of the spec)
