### PR TITLE
Tidy up VGIS spec descriptions

### DIFF
--- a/definitions/vonage-business-cloud/vgis.yml
+++ b/definitions/vonage-business-cloud/vgis.yml
@@ -160,7 +160,7 @@ paths:
             #format: date
         - in: query
           name: direction
-          description: Filter by call direction
+          description: Filter by call direction. For multiple criteria, seperate values by a comma.
           schema:
             type: string
             example: INBOUND,OUTBOUND
@@ -169,7 +169,7 @@ paths:
               - OUTBOUND
         - in: query
           name: states
-          description: Filter calls by state
+          description: Filter calls by state. For multiple criteria, seperate values by a comma.
           schema:
             type: string
             default: ACTIVE
@@ -261,7 +261,7 @@ paths:
             #format: date
         - in: query
           name: direction
-          description: Filter by call direction
+          description: Filter by call direction. For multiple criteria, seperate values by a comma.
           schema:
             type: string
             example: INBOUND,OUTBOUND
@@ -270,7 +270,7 @@ paths:
               - OUTBOUND
         - in: query
           name: states
-          description: Filter calls by state
+          description: Filter calls by state. For multiple criteria, seperate values by a comma.
           schema:
             type: string
             default: ACTIVE
@@ -1460,7 +1460,6 @@ components:
                 type: integer
                 format: int64
               ucpLabel:
-                description: "{ucpName} ({ucpType})"
                 type: string
               health:
                 type: object
@@ -1509,7 +1508,6 @@ components:
                 type: integer
                 format: int64
               ucpLabel:
-                description: "{ucpName} ({ucpType})"
                 type: string
               ucpAccountId:
                 type: string

--- a/definitions/vonage-business-cloud/vgis.yml
+++ b/definitions/vonage-business-cloud/vgis.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   description: Vonage Integration Suite
-  version: 1.0.0
+  version: 1.0.1
   title: Vonage Integration Suite
   contact:
     email: gunifydevops@vonage.com


### PR DESCRIPTION
# Description

- Removed unclear and shortly-to-be-deprecated `ucis.ucpLabel` description.
- Multiple `direction` and `states` filters must be comma-separated.

# Checklist

- [X] version number incremented (in the `info` section of the spec)
