### PR TITLE
Add HTTP responses for VAPI PUT request

### DIFF
--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: 1.1.0
+  version: 1.2.0
   title: Voice API
   description: The Voice API lets you create outbound calls, control in-progress calls
     and get information about historical calls. More information about the Voice API

--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -380,6 +380,10 @@ paths:
       responses:
         '204':
           description: No Content
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
   "/calls/{uuid}/stream":
     parameters:
     - in: path


### PR DESCRIPTION
# Description

This adds the 401 and 404 HTTP responses for a `PUT` request to `/calls/:call_id`. 
# Checklist

- [x] version number incremented (in the `info` section of the spec)
