### PR TITLE
Add links to renderer tool and spec renderings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # API Specifications
 
-Provides Open API Specification 3 definitions for Nexmo APIs.
+
+Provides [OpenAPI Specification (v3)](https://github.com/OAI/OpenAPI-Specification) definitions for Nexmo APIs.
+
+## Human-readable specifications
+
+[View rendered API specifications](https://nexmo-api-specification.herokuapp.com/)
+
+_(Raw specification files are in `definitions/`)_
+
+## About OpenAPI
 
 These definitions provide a single point of truth that can be used end-to-end:
 
@@ -9,23 +18,6 @@ These definitions provide a single point of truth that can be used end-to-end:
 - **Testing** As the basis for testing or mocking API endpoints
 - **Documentation** For producing thorough and interactive documentation
 - **Tooling** To generate server stubs and client SDKs.
-
-## Definitions
-
-| API | Definition owner | Contributors |
-| --- | ---------------- | ------------ |
-| SMS | - | Adam Butler |
-| Voice | - | - |
-| Verify | - | Adam Butler, Mike Ralphson |
-| Number Insight | - | Adam Butler, Mike Ralphson |
-| Conversation | Neil Stratford | Adam Butler |
-| Olympus | Hugh Hopkins |
-| Account | - | - |
-| Messages | - | - |
-| Messages | - | - |
-| Numbers | - | - |
-| Application | - | - |
-| Conversion | - | - |
 
 ## Resources
 
@@ -37,11 +29,11 @@ These definitions provide a single point of truth that can be used end-to-end:
 
 ## Tools
 
+- [Nexmo OAS Renderer](https://github.com/Nexmo/nexmo-oas-renderer) - Nexmo's tool for rendering OpenAPI specs to HTML.
+- [Nexmo Developer](https://github.com/Nexmo/nexmo-developer) - Nexmo Developer uses these specs and the renderer for the API reference pages.
 - [Swagger Editor](http://editor.swagger.io/) - Can be used to edit OAS3 definitions, provides live reloading Swagger UI.
-- [Swagger 2.0 to OAS3 converter](https://openapi-converter.herokuapp.com/) - Unofficial converter that can be used to convert existing Swagger 2.0 definitions to OAS3 definitions.
 - [Swagger Codegen](https://github.com/swagger-api/swagger-codegen) - A template-driven engine to generate documentation, API clients and server stubs in different languages by parsing OAS3 definitions.
 - [Swagger Parser](https://github.com/swagger-api/swagger-parser) - Standalone library for parsing OAS3 definitions from Java
-- [Nexmo Developer](https://github.com/Nexmo/nexmo-developer) - Nexmo Developer has its own OAS3 definition parser and API reference UI.
 
 ## Contributing
 


### PR DESCRIPTION
# Description

A little `README` update! This change:
* Adds a link to the `oas-renderer`
* Adds a link to the rendered specs that we just added, so people can find them
* Removes a table of specs that we're not maintaining and I'm not sure how useful it was
