### PR TITLE
Add estimated price field to search endpoint

### DIFF
--- a/definitions/verify.yml
+++ b/definitions/verify.yml
@@ -3,7 +3,7 @@ servers:
   - url: 'https://api.nexmo.com/verify'
 info:
   title: Nexmo Verify API
-  version: 1.0.5
+  version: 1.0.6
   description: >-
     The Verify API helps you to implement 2FA (two-factor authentication) in your applications.
     This is useful for:
@@ -202,7 +202,7 @@ paths:
           required: false
           in: query
           description: >-
-            How log the generated verification code is valid for, in seconds.
+            How long the generated verification code is valid for, in seconds.
             When you specify both `pin_expiry` and `next_event_wait` then
             `pin_expiry` must be an integer multiple of `next_event_wait`
             otherwise `pin_expiry` is defaulted to equal next_event_wait. See
@@ -431,6 +431,10 @@ components:
           - xml
       example: json
   schemas:
+    estimated_price_messages_sent:
+      type: string
+      description: Estimated cost of calls made and messages sent; the total cost of the verification is the sum of this field and the `price` field. The value can change in the future if another event is taking place when the code is entered. For older accounts, this field is not present (only the `price` field is needed to calculate the cost in that case).
+      example: "0.03330000"
     requestResponse:
       type: object
       xml:
@@ -532,9 +536,7 @@ components:
           description: The currency code.
           example: EUR
         estimated_price_messages_sent:
-          type: string
-          description: Estimated cost of calls made and messages sent; the total cost of the verification is the sum of this field and the `price` field. The value can change in the future if another event is taking place when the code is entered. For older accounts, this field is not present (only the `price` field is needed to calculate the cost in that case).
-          example: "0.03330000"
+          $ref: '#/components/schemas/estimated_price_messages_sent'
       xml:
         name: verify_response
     checkErrorResponse:
@@ -709,6 +711,8 @@ components:
                   - sms
               id:
                 type: string
+        estimated_price_messages_sent:
+          $ref: '#/components/schemas/estimated_price_messages_sent'
     searchErrorResponse:
       xml:
         name: verify_request

--- a/definitions/verify.yml
+++ b/definitions/verify.yml
@@ -433,7 +433,13 @@ components:
   schemas:
     estimated_price_messages_sent:
       type: string
-      description: Estimated cost of calls made and messages sent; the total cost of the verification is the sum of this field and the `price` field. The value can change in the future if another event is taking place when the code is entered. For older accounts, this field is not present (only the `price` field is needed to calculate the cost in that case).
+      description: |
+        This field may not be present, depending on your pricing model. The
+        value indicates the cost (in EUR) of the calls made and messages sent
+        for the verification process. This value may be updated during and
+        shortly after the request completes because user input events can
+        overlap with message/call events. When this field is present, the total
+        cost of the verification is the sum of this field and the `price` field.
       example: "0.03330000"
     requestResponse:
       type: object


### PR DESCRIPTION
# Description

# New

Add the new `estimated_price_messages_sent` field to the search endpoint.

This field was already returned by the `check/` endpoint but has now been added to the search as well. Refactored to make this field reusable.

# Checklist

- [x] version number incremented (in the `info` section of the spec)
