### PR TITLE
Add an endpoint for PSD2 to Verify API

### DIFF
--- a/definitions/verify.yml
+++ b/definitions/verify.yml
@@ -382,7 +382,7 @@ paths:
   '/psd2/{format}':
     get:
       operationId: verifyRequestWithPSD2
-      summary: Payment Standards Directive Verify Request
+      summary: PSD2 (Payment Services Directive 2) Request
       description: >-
         Use Verify request to generate and send a PIN to your user to authorize a payment:
 
@@ -393,7 +393,7 @@ paths:
 
         3. Use the `request_id` field in the response for the Verify check.
 
-        _Please note that XML format is not supported for the Payment Services Directive endpoint at this time._
+        (Please note that XML format is not supported for the Payment Services Directive endpoint at this time.)
 
       parameters:
         - $ref: '#/components/parameters/api_secret'

--- a/definitions/verify.yml
+++ b/definitions/verify.yml
@@ -395,6 +395,7 @@ paths:
 
       parameters:
         - $ref: '#/components/parameters/format'
+        - $ref: '#/components/parameters/api_secret'
         - name: number
           required: true
           in: query

--- a/definitions/verify.yml
+++ b/definitions/verify.yml
@@ -393,9 +393,19 @@ paths:
 
         3. Use the `request_id` field in the response for the Verify check.
 
+        _Please note that XML format is not supported for the Payment Services Directive endpoint at this time._
+
       parameters:
-        - $ref: '#/components/parameters/format'
         - $ref: '#/components/parameters/api_secret'
+        - name: format
+          required: true
+          in: path
+          description: The response format (only JSON is supported at this time)
+          schema:
+            type: string
+            enum:
+              - json
+          example: json
         - name: number
           required: true
           in: query
@@ -430,7 +440,7 @@ paths:
           required: true
           in: query
           description: >-
-            A decimal amount for the payment to be confirmed.
+            A decimal amount for the payment to be confirmed, in Euros
           schema:
             type: number
             format: float
@@ -551,12 +561,7 @@ paths:
               schema:
                 oneOf:
                   - $ref: '#/components/schemas/requestResponse'
-                  - $ref: '#/components/schemas/requestErrorResponse'
-            text/xml:
-              schema:
-                oneOf:
-                  - $ref: '#/components/schemas/requestResponse'
-                  - $ref: '#/components/schemas/requestErrorResponse'
+                  - $ref: '#/components/schemas/psdErrorResponse'
 components:
   parameters:
     format:
@@ -977,6 +982,65 @@ components:
           type: string
           description: If the `status` is non-zero, this explains the error encountered.
           example: The requestId 'abcdef0123456789abcdef' does not exist or its no longer active.
+    psdErrorResponse:
+      type: object
+      description: Error
+      properties:
+        request_id:
+          type: string
+          description: >-
+            The unique ID of the Verify request. This may be blank in an error situation
+          maxLength: 32
+          example: abcdef012345...
+        status:
+          type: string
+          example: '2'
+          enum:
+            - '0'
+            - '1'
+            - '2'
+            - '3'
+            - '4'
+            - '5'
+            - '6'
+            - '7'
+            - '8'
+            - '9'
+            - '10'
+            - '15'
+            - '16'
+            - '17'
+            - '18'
+            - '19'
+            - '20'
+            - '21'
+            - '101'
+          description: |
+            Code | Text | Description
+            -- | -- | --
+            0 | Success | The request was successfully accepted by Nexmo.
+            1 | Throttled | You are trying to send more than the maximum of 30 requests per second.
+            2 | Your request is incomplete and missing the mandatory parameter `$parameter` | The stated parameter is missing.
+            3 | Invalid value for parameter `$parameter` | Invalid value for parameter. If you see Facility not allowed in the error text, check that you are using the correct Base URL in your request.
+            4 | Invalid credentials were provided | The supplied API key or secret in the request is either invalid or disabled.
+            5 | Internal Error | An error occurred processing this request in the Cloud Communications Platform.
+            6 | The Nexmo platform was unable to process this message for the following reason: `$reason` | The request could not be routed.
+            7 | The number you are trying to verify is blacklisted for verification. |
+            8 | The api_key you supplied is for an account that has been barred from submitting messages. |
+            9 | Partner quota exceeded | Your account does not have sufficient credit to process this request.
+            10 | Concurrent verifications to the same number are not allowed | 
+            15 | The destination number is not in a supported network | The request has been rejected. Find out more about this error in the [Knowledge Base](https://help.nexmo.com/hc/en-us/articles/360018406532-Verify-On-demand-Service-to-High-Risk-Countries)
+            16 | The code inserted does not match the expected value |
+            17 | The wrong code was provided too many times | You can run Verify check on a specific `request_id` up to three times unless a new verification code is generated. If you check a request more than three times, it is set to FAILED and you cannot check it again.
+            18 | Too many request_ids provided | You added more than the maximum ten `request_id`s to your request.
+            19 | No more events are left to execute for this request |
+            20 | This account does not support the parameter: pin_code. | Only certain accounts have the ability to set the `pin_code`. Please contact your account manager for more information.
+            21 | This account does not support the PSD2 feature. Please contact support for more information at support@nexmo.com. |
+            101 | No request found | There are no matching verify requests.
+        error_text:
+          type: string
+          description: 'If `status` is non-zero, this explains the error encountered.'
+          example: 'Your request is incomplete and missing the mandatory parameter `number`'
   securitySchemes:
     apiKey:
       type: apiKey

--- a/definitions/verify.yml
+++ b/definitions/verify.yml
@@ -379,6 +379,183 @@ paths:
                 oneOf:
                   - $ref: "#/components/schemas/controlResponse"
                   - $ref: "#/components/schemas/controlErrorResponse"
+  '/psd2/{format}':
+    get:
+      operationId: verifyRequestWithPSD2
+      summary: Payment Standards Directive Verify Request
+      description: >-
+        Use Verify request to generate and send a PIN to your user to authorise a payment:
+
+        1. Create a request to send a verification code to your user.
+
+        2. Check the `status` field in the response to ensure that your request
+        was successful (zero is success).
+
+        3. Use the `request_id` field in the response for the Verify check.
+
+      parameters:
+        - $ref: '#/components/parameters/format'
+        - name: number
+          required: true
+          in: query
+          description: >-
+            The mobile or landline phone number to verify. Unless you are
+            setting `country` explicitly, this number must be in
+            [E.164](https://en.wikipedia.org/wiki/E.164) format.
+          schema:
+            type: string
+          example: '447700900000'
+        - name: country
+          required: false
+          in: query
+          description: >-
+            If you do not provide `number` in international format or you are not
+            sure if `number` is correctly formatted, specify the two-character country
+            code in `country`. Verify will then format the number for you.
+          schema:
+            type: string
+          example: GB
+        - name: payee
+          required: true
+          in: query
+          description: >-
+            An alphanumeric string to indicate to the user the name of the recipient
+            that they are confirming a payment to.
+          schema:
+            type: string
+            maxLength: 30
+          example: Online Retailer Inc
+        - name: amount
+          required: true
+          in: query
+          description: >-
+            A decimal amount for the payment to be confirmed.
+          schema:
+            type: number
+            format: float
+          example: '48.00'
+        - name: sender_id
+          required: false
+          in: query
+          description: >-
+            An 11-character alphanumeric string that represents the [identity of the sender](https://developer.nexmo.com/messaging/sms/guides/custom-sender-id) 
+            of the verification request. Depending on the destination of the phone number you are sending the verification SMS to,
+            restrictions might apply.
+          schema:
+            type: string
+            maxLength: 11
+            default: VERIFY
+          example: RETAILER
+        - name: code_length
+          required: false
+          in: query
+          description: The length of the verification code.
+          schema:
+            type: integer
+            enum:
+              - 4
+              - 6
+            default: 4
+          example: 6
+        - name: lg
+          required: false
+          in: query
+          description: >-
+            By default, the SMS or text-to-speech (TTS) message is generated in
+            the locale that matches the `number`. For example, the text message
+            or TTS message for a `33*` number is sent in French. Use this
+            parameter to explicitly control the language, accent and gender used
+            for the Verify request.
+          example: en-us
+          schema:
+            type: string
+            default: en-us
+            enum:
+              - de-de
+              - en-au
+              - en-gb
+              - en-us
+              - en-in
+              - es-es
+              - es-mx
+              - es-us
+              - fr-ca
+              - fr-fr
+              - is-is
+              - it-it
+              - ja-jp
+              - ko-kr
+              - nl-nl
+              - pl-pl
+              - pt-pt
+              - pt-br
+              - ro-ro
+              - ru-ru
+              - sv-se
+              - tr-tr
+              - zh-cn
+              - zh-tw
+        - name: pin_expiry
+          required: false
+          in: query
+          description: >-
+            How log the generated verification code is valid for, in seconds.
+            When you specify both `pin_expiry` and `next_event_wait` then
+            `pin_expiry` must be an integer multiple of `next_event_wait`
+            otherwise `pin_expiry` is defaulted to equal next_event_wait. See
+            [changing the event
+            timings](https://developer.nexmo.com/verify/guides/changing-default-timings).
+          schema:
+            type: integer
+            minimum: 60
+            maximum: 3600
+            default: 300
+          example: 240
+        - name: next_event_wait
+          required: false
+          in: query
+          description: >-
+            Specifies the wait time in seconds between attempts to deliver the
+            verification code. 
+          schema:
+            type: integer
+            minimum: 60
+            maximum: 900
+            default: 300
+          example: 120
+        - name: workflow_id
+          required: false
+          in: query
+          description: >-
+            Selects the predefined sequence of SMS and TTS (Text To Speech)
+            actions to use in order to convey the PIN to your user. For example,
+            an id of 1 identifies the workflow SMS - TTS - TTS. For a list of
+            all workflows and their associated ids, please visit the [developer
+            portal](https://developer.nexmo.com/verify/guides/workflows-and-events).
+          schema:
+            type: integer
+            default: 1
+            enum:
+              - 1
+              - 2
+              - 3
+              - 4
+              - 5
+          example: 4
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/requestResponse'
+                  - $ref: '#/components/schemas/requestErrorResponse'
+            text/xml:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/requestResponse'
+                  - $ref: '#/components/schemas/requestErrorResponse'
 components:
   parameters:
     format:

--- a/definitions/verify.yml
+++ b/definitions/verify.yml
@@ -384,7 +384,7 @@ paths:
       operationId: verifyRequestWithPSD2
       summary: Payment Standards Directive Verify Request
       description: >-
-        Use Verify request to generate and send a PIN to your user to authorise a payment:
+        Use Verify request to generate and send a PIN to your user to authorize a payment:
 
         1. Create a request to send a verification code to your user.
 
@@ -435,12 +435,12 @@ paths:
           schema:
             type: string
             maxLength: 30
-          example: Online Retailer Inc
+          example: Acme Inc
         - name: amount
           required: true
           in: query
           description: >-
-            A decimal amount for the payment to be confirmed, in Euros
+            The decimal amount of the payment to be confirmed, in Euros
           schema:
             type: number
             format: float
@@ -449,9 +449,11 @@ paths:
           required: false
           in: query
           description: >-
-            An 11-character alphanumeric string that represents the [identity of the sender](https://developer.nexmo.com/messaging/sms/guides/custom-sender-id) 
-            of the verification request. Depending on the destination of the phone number you are sending the verification SMS to,
-            restrictions might apply.
+            An 11-character alphanumeric string that represents the
+            [identity of the sender](https://developer.nexmo.com/messaging/sms/guides/custom-sender-id)
+            of the verification request. Depending on the destination of the
+            phone number you are sending the verification SMS to, restrictions
+            might apply. There is [more information on our Knowledgebase](https://help.nexmo.com/hc/en-us/articles/115011781468).
           schema:
             type: string
             maxLength: 11
@@ -510,10 +512,10 @@ paths:
           required: false
           in: query
           description: >-
-            How log the generated verification code is valid for, in seconds.
+            How long the generated verification code is valid for, in seconds.
             When you specify both `pin_expiry` and `next_event_wait` then
             `pin_expiry` must be an integer multiple of `next_event_wait`
-            otherwise `pin_expiry` is defaulted to equal next_event_wait. See
+            otherwise `pin_expiry` defaults to equal `next_event_wait`. See
             [changing the event
             timings](https://developer.nexmo.com/verify/guides/changing-default-timings).
           schema:

--- a/definitions/verify.yml
+++ b/definitions/verify.yml
@@ -3,7 +3,7 @@ servers:
   - url: "https://api.nexmo.com/verify"
 info:
   title: Nexmo Verify API
-  version: 1.0.8
+  version: 1.0.9
   description: >-
     The Verify API helps you to implement 2FA (two-factor authentication) in your applications.
     This is useful for:

--- a/definitions/verify.yml
+++ b/definitions/verify.yml
@@ -50,26 +50,8 @@ paths:
       parameters:
         - $ref: "#/components/parameters/format"
         - $ref: "#/components/parameters/api_secret"
-        - name: number
-          required: true
-          in: query
-          description: >-
-            The mobile or landline phone number to verify. Unless you are
-            setting `country` explicitly, this number must be in
-            [E.164](https://en.wikipedia.org/wiki/E.164) format.
-          schema:
-            type: string
-          example: "447700900000"
-        - name: country
-          required: false
-          in: query
-          description: >-
-            If you do not provide `number` in international format or you are not
-            sure if `number` is correctly formatted, specify the two-character country
-            code in `country`. Verify will then format the number for you.
-          schema:
-            type: string
-          example: GB
+        - $ref: "#/components/parameters/number"
+        - $ref: "#/components/parameters/country"
         - name: brand
           required: true
           in: query
@@ -81,29 +63,8 @@ paths:
             type: string
             maxLength: 18
           example: Acme Inc
-        - name: sender_id
-          required: false
-          in: query
-          description: >-
-            An 11-character alphanumeric string that represents the [identity of the sender](https://developer.nexmo.com/messaging/sms/guides/custom-sender-id) 
-            of the verification request. Depending on the destination of the phone number you are sending the verification SMS to,
-            restrictions might apply.
-          schema:
-            type: string
-            maxLength: 11
-            default: VERIFY
-          example: ACME
-        - name: code_length
-          required: false
-          in: query
-          description: The length of the verification code.
-          schema:
-            type: integer
-            enum:
-              - 4
-              - 6
-            default: 4
-          example: 6
+        - $ref: "#/components/parameters/sender_id"
+        - $ref: "#/components/parameters/code_length"
         - name: lg
           required: false
           in: query
@@ -113,7 +74,7 @@ paths:
             or TTS message for a `33*` number is sent in French. Use this
             parameter to explicitly control the language used for the Verify
             request. A list of languages is available: <https://developer.nexmo.com/verify/guides/verify-languages>
-          example: en-us
+          example: de-de
           schema:
             type: string
             default: en-us
@@ -155,55 +116,9 @@ paths:
               - vi-vn
               - zh-cn
               - zh-tw
-        - name: pin_expiry
-          required: false
-          in: query
-          description: >-
-            How long the generated verification code is valid for, in seconds.
-            When you specify both `pin_expiry` and `next_event_wait` then
-            `pin_expiry` must be an integer multiple of `next_event_wait`
-            otherwise `pin_expiry` is defaulted to equal next_event_wait. See
-            [changing the event
-            timings](https://developer.nexmo.com/verify/guides/changing-default-timings).
-          schema:
-            type: integer
-            minimum: 60
-            maximum: 3600
-            default: 300
-          example: 240
-        - name: next_event_wait
-          required: false
-          in: query
-          description: >-
-            Specifies the wait time in seconds between attempts to deliver the
-            verification code.
-          schema:
-            type: integer
-            minimum: 60
-            maximum: 900
-            default: 300
-          example: 120
-        - name: workflow_id
-          required: false
-          in: query
-          description: >-
-            Selects the predefined sequence of SMS and TTS (Text To Speech)
-            actions to use in order to convey the PIN to your user. For example,
-            an id of 1 identifies the workflow SMS - TTS - TTS. For a list of
-            all workflows and their associated ids, please visit the [developer
-            portal](https://developer.nexmo.com/verify/guides/workflows-and-events).
-          schema:
-            type: integer
-            default: 1
-            enum:
-              - 1
-              - 2
-              - 3
-              - 4
-              - 5
-              - 6
-              - 7
-          example: 4
+        - $ref: "#/components/parameters/pin_expiry"
+        - $ref: "#/components/parameters/next_event_wait"
+        - $ref: "#/components/parameters/workflow_id"
       responses:
         "200":
           description: OK
@@ -233,16 +148,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/format"
         - $ref: "#/components/parameters/api_secret"
-        - name: request_id
-          required: true
-          in: query
-          description: >-
-            The Verify request to check. This is the
-            `request_id` you received in the response to the Verify request.
-          schema:
-            type: string
-            maxLength: 32
-          example: abcdef012345...
+        - $ref: "#/components/parameters/request_id"
         - name: code
           required: true
           in: query
@@ -290,13 +196,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/format"
         - $ref: "#/components/parameters/api_secret"
-        - name: request_id
-          required: false
-          in: query
-          description: The `request_id` you received in the Verify Request Response.
-          schema:
-            type: string
-          example: abcdef012345...
+        - $ref: "#/components/parameters/request_id"
         - name: request_ids
           required: false
           in: query
@@ -339,13 +239,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/format"
         - $ref: "#/components/parameters/api_secret"
-        - name: request_id
-          required: true
-          in: query
-          description: "The `request_id` you received in the response to the Verify request."
-          schema:
-            type: string
-          example: abcdef012345...
+        - $ref: "#/components/parameters/request_id"
         - name: cmd
           required: true
           in: query
@@ -406,26 +300,8 @@ paths:
             enum:
               - json
           example: json
-        - name: number
-          required: true
-          in: query
-          description: >-
-            The mobile or landline phone number to verify. Unless you are
-            setting `country` explicitly, this number must be in
-            [E.164](https://en.wikipedia.org/wiki/E.164) format.
-          schema:
-            type: string
-          example: '447700900000'
-        - name: country
-          required: false
-          in: query
-          description: >-
-            If you do not provide `number` in international format or you are not
-            sure if `number` is correctly formatted, specify the two-character country
-            code in `country`. Verify will then format the number for you.
-          schema:
-            type: string
-          example: GB
+        - $ref: '#/components/parameters/number'
+        - $ref: '#/components/parameters/country'
         - name: payee
           required: true
           in: query
@@ -445,31 +321,8 @@ paths:
             type: number
             format: float
           example: '48.00'
-        - name: sender_id
-          required: false
-          in: query
-          description: >-
-            An 11-character alphanumeric string that represents the
-            [identity of the sender](https://developer.nexmo.com/messaging/sms/guides/custom-sender-id)
-            of the verification request. Depending on the destination of the
-            phone number you are sending the verification SMS to, restrictions
-            might apply. There is [more information on our Knowledgebase](https://help.nexmo.com/hc/en-us/articles/115011781468).
-          schema:
-            type: string
-            maxLength: 11
-            default: VERIFY
-          example: RETAILER
-        - name: code_length
-          required: false
-          in: query
-          description: The length of the verification code.
-          schema:
-            type: integer
-            enum:
-              - 4
-              - 6
-            default: 4
-          example: 6
+        - $ref: "#/components/parameters/sender_id"
+        - $ref: "#/components/parameters/code_length"
         - name: lg
           required: false
           in: query
@@ -477,84 +330,53 @@ paths:
             By default, the SMS or text-to-speech (TTS) message is generated in
             the locale that matches the `number`. For example, the text message
             or TTS message for a `33*` number is sent in French. Use this
-            parameter to explicitly control the language, accent and gender used
-            for the Verify request.
-          example: en-us
+            parameter to explicitly control the language used for the Verify
+            request. A list of languages is available: <https://developer.nexmo.com/verify/guides/verify-languages>
+          example: es-es
           schema:
             type: string
             default: en-us
             enum:
+              - ar-xa
+              - cs-cz
+              - cy-cy
+              - cy-gb
+              - da-dk
               - de-de
+              - el-gr
               - en-au
               - en-gb
-              - en-us
               - en-in
+              - en-us
               - es-es
               - es-mx
               - es-us
+              - fi-fi
+              - fil-ph
               - fr-ca
               - fr-fr
+              - hi-in
+              - hu-hu
+              - id-id
               - is-is
               - it-it
               - ja-jp
               - ko-kr
+              - nb-no
               - nl-nl
               - pl-pl
-              - pt-pt
               - pt-br
+              - pt-pt
               - ro-ro
               - ru-ru
               - sv-se
               - tr-tr
+              - vi-vn
               - zh-cn
               - zh-tw
-        - name: pin_expiry
-          required: false
-          in: query
-          description: >-
-            How long the generated verification code is valid for, in seconds.
-            When you specify both `pin_expiry` and `next_event_wait` then
-            `pin_expiry` must be an integer multiple of `next_event_wait`
-            otherwise `pin_expiry` defaults to equal `next_event_wait`. See
-            [changing the event
-            timings](https://developer.nexmo.com/verify/guides/changing-default-timings).
-          schema:
-            type: integer
-            minimum: 60
-            maximum: 3600
-            default: 300
-          example: 240
-        - name: next_event_wait
-          required: false
-          in: query
-          description: >-
-            Specifies the wait time in seconds between attempts to deliver the
-            verification code. 
-          schema:
-            type: integer
-            minimum: 60
-            maximum: 900
-            default: 300
-          example: 120
-        - name: workflow_id
-          required: false
-          in: query
-          description: >-
-            Selects the predefined sequence of SMS and TTS (Text To Speech)
-            actions to use in order to convey the PIN to your user. For example,
-            an id of 1 identifies the workflow SMS - TTS - TTS. For a list of
-            all workflows and their associated ids, please visit the [developer
-            portal](https://developer.nexmo.com/verify/guides/workflows-and-events).
-          schema:
-            type: integer
-            default: 1
-            enum:
-              - 1
-              - 2
-              - 3
-              - 4
-              - 5
-          example: 4
+        - $ref: "#/components/parameters/pin_expiry"
+        - $ref: "#/components/parameters/next_event_wait"
+        - $ref: "#/components/parameters/workflow_id"
       responses:
         '200':
           description: OK
@@ -586,6 +408,116 @@ components:
         dashboard](https://dashboard.nexmo.com)
       schema:
         type: string
+    number:
+      name: number
+      required: true
+      in: query
+      description: >-
+        The mobile or landline phone number to verify. Unless you are
+        setting `country` explicitly, this number must be in
+        [E.164](https://en.wikipedia.org/wiki/E.164) format.
+      schema:
+        type: string
+      example: '447700900000'
+    country:
+      name: country
+      required: false
+      in: query
+      description: >-
+        If you do not provide `number` in international format or you are not
+        sure if `number` is correctly formatted, specify the two-character country
+        code in `country`. Verify will then format the number for you.
+      schema:
+        type: string
+      example: GB
+    sender_id:
+      name: sender_id
+      required: false
+      in: query
+      description: >-
+        An 11-character alphanumeric string that represents the [identity of the sender](https://developer.nexmo.com/messaging/sms/guides/custom-sender-id) 
+        of the verification request. Depending on the destination of the phone number you are sending the verification SMS to,
+        restrictions might apply.
+      schema:
+        type: string
+        maxLength: 11
+        default: VERIFY
+      example: ACME
+    code_length:
+      name: code_length
+      required: false
+      in: query
+      description: The length of the verification code.
+      schema:
+        type: integer
+        enum:
+          - 4
+          - 6
+        default: 4
+      example: 6
+    pin_expiry:
+      name: pin_expiry
+      required: false
+      in: query
+      description: >-
+        How long the generated verification code is valid for, in seconds.
+        When you specify both `pin_expiry` and `next_event_wait` then
+        `pin_expiry` must be an integer multiple of `next_event_wait`
+        otherwise `pin_expiry` defaults to equal `next_event_wait`. See
+        [changing the event
+        timings](https://developer.nexmo.com/verify/guides/changing-default-timings).
+      schema:
+        type: integer
+        minimum: 60
+        maximum: 3600
+        default: 300
+      example: 240
+    next_event_wait:
+      name: next_event_wait
+      required: false
+      in: query
+      description: >-
+        Specifies the wait time in seconds between attempts to deliver the
+        verification code. 
+      schema:
+        type: integer
+        minimum: 60
+        maximum: 900
+        default: 300
+      example: 120
+    workflow_id:
+      name: workflow_id
+      required: false
+      in: query
+      description: >-
+        Selects the predefined sequence of SMS and TTS (Text To Speech)
+        actions to use in order to convey the PIN to your user. For example,
+        an id of 1 identifies the workflow SMS - TTS - TTS. For a list of
+        all workflows and their associated ids, please visit the [developer
+        portal](https://developer.nexmo.com/verify/guides/workflows-and-events).
+      schema:
+        type: integer
+        default: 1
+        enum:
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+      example: 4
+    request_id:
+      name: request_id
+      required: true
+      in: query
+      description: >-
+        The `request_id` you received in the response to the Verify request.
+      schema:
+        type: string
+        maxLength: 32
+      example: abcdef012345...
+
   schemas:
     estimated_price_messages_sent:
       type: string


### PR DESCRIPTION
# Description

This is just a draft for discussion, while we finalise and then build this feature.

# New

Add the `/verify/psd` endpoint to the Verify API for the new payment standards directive functionality.

# Checklist

- [ ] version number incremented (in the `info` section of the spec)
(version number not incremented yet, needs to be before merge)