### PR TITLE
Bump version two revisions

### DIFF
--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: 0.3.1
+  version: 0.3.3
   title: Messages API
   description: 'The Messaging API is a new API that consolidates all messaging channels. It encapsulates a user (developer) from having to use multiple APIs to interact with our various channels such as SMS, MMS, Viber, Facebook Messenger, etc. The API normalises information across all channels to abstracted to, from and content. This API is currently in Beta.'
   contact:


### PR DESCRIPTION
# Description

Bump version number two revisions as `custom` and `video` were added to spec but an oversight meant the revision number was not incremented on both occasions.

# New 

* Added `custom` object to WhatsApp messaging.
* Added `video` to WhatsApp messaging.

# Checklist

- [x] version number incremented (in the `info` section of the spec)
