### PR TITLE
V2 not beta. V1 deprecated.

### DIFF
--- a/definitions/application.v2.yml
+++ b/definitions/application.v2.yml
@@ -1,14 +1,12 @@
 ---
 openapi: "3.0.0"
 info:
-  version: 1.0.3
+  version: 2.0.4
   title: "Application API"
   description: |
-    This is the *beta* version of the Application API.
-
     Nexmo provides an Application API to allow management of your Nexmo Applications.
 
-    This API is backwards compatible with version 1. Applications created using Version 1 of the API can also be managed using Version 2.
+    This API is backwards compatible with version 1. Applications created using version 1 of the API can also be managed using version 2 (this version) of the API.
   contact:
     name: Nexmo
     url: 'https://developer.nexmo.com/'

--- a/definitions/application.yml
+++ b/definitions/application.yml
@@ -1,8 +1,10 @@
 openapi: 3.0.0
 info:
   title: Nexmo Application API
-  version: 1.0.1
+  version: 1.0.2
   description: >-
+    **This version of the API is now deprecated. Please see [version 2](/api/application.v2).**
+    
     A Nexmo application contains the security and configuration information you
     need to connect to Nexmo endpoints and easily use our products.
   contact:

--- a/definitions/application.yml
+++ b/definitions/application.yml
@@ -3,8 +3,14 @@ info:
   title: Nexmo Application API
   version: 1.0.2
   description: >-
-    **This version of the API is now deprecated. Please see [version 2](/api/application.v2).**
-    
+    <div class="Vlt-callout Vlt-callout--critical">
+    <i></i>
+    <div class="Vlt-callout__content">
+      <h4>Applications V1 is deprecated</h4>
+      This version of the API has been deprecated. Please use <a href="/api/application.v2">version 2</a> going forwards
+    </div>
+    </div>
+
     A Nexmo application contains the security and configuration information you
     need to connect to Nexmo endpoints and easily use our products.
   contact:


### PR DESCRIPTION
# New 

* Application API V1 is now deprecated. It has been marked as deprecated with a link to V2 API reference.
* Application API V2 is now promoted from Beta to GA.
* Application API V2 version number was incorrectly on 1.x.x. Promoted to 2.x.x with a revision increment.

# Checklist

- [x] version number incremented (in the `info` section of the spec)
