### PR TITLE
Fix voice update

### DIFF
--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -391,7 +391,7 @@ paths:
       schema:
         type: string
       required: true
-      description: UUID of the Leg
+      description: UUID of the Call Leg
       example: 63f61863-4a51-4f6b-86e1-46edebcf9356
     put:
       security:
@@ -465,7 +465,7 @@ paths:
       schema:
         type: string
       required: true
-      description: UUID of the Leg
+      description: UUID of the Call Leg
       example: 63f61863-4a51-4f6b-86e1-46edebcf9356
     put:
       security:
@@ -538,7 +538,7 @@ paths:
       schema:
         type: string
       required: true
-      description: UUID of the Leg
+      description: UUID of the Call Leg
       example: 63f61863-4a51-4f6b-86e1-46edebcf9356
     put:
       security:

--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: 1.2.0
+  version: 1.2.1
   title: Voice API
   description: The Voice API lets you create outbound calls, control in-progress calls
     and get information about historical calls. More information about the Voice API
@@ -391,7 +391,7 @@ paths:
       schema:
         type: string
       required: true
-      description: UUID of the Call
+      description: UUID of the Leg
       example: 63f61863-4a51-4f6b-86e1-46edebcf9356
     put:
       security:

--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -465,7 +465,7 @@ paths:
       schema:
         type: string
       required: true
-      description: UUID of the Call
+      description: UUID of the Leg
       example: 63f61863-4a51-4f6b-86e1-46edebcf9356
     put:
       security:
@@ -538,7 +538,7 @@ paths:
       schema:
         type: string
       required: true
-      description: UUID of the Call
+      description: UUID of the Leg
       example: 63f61863-4a51-4f6b-86e1-46edebcf9356
     put:
       security:
@@ -623,7 +623,7 @@ components:
     uuid:
       type: string
       format: uuid
-      title: The UUID of the Call
+      title: The UUID of the Leg
       example: 63f61863-4a51-4f6b-86e1-46edebcf9356
       description: >-
           The unique identifier for this call leg. The UUID is created when


### PR DESCRIPTION
# Description

<!--

The following will be used in our release notes and public changelog. Communicate well!

Example:

# New 

* Added new `/foobar/sync` endpoint to toggle widget status
* The `GET /v1/calls` endpoint now supports a `to` query parameter to filter calls to a single number

# Fixes

* Add HTTP 401 and 403 error code documentation to the `/v1/calls` endpoint
-->

# Checklist

- [x] version number incremented (in the `info` section of the spec)
