### PR TITLE
Switch to basic spectral validation of built-in rules

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,0 +1,9 @@
+extends: spectral:oas3
+rules: 
+  operation-tags: false
+  operation-description: false
+  valid-example-in-schemas: false
+  valid-schema-example-in-content: false
+  valid-schema-example-in-parameters: false
+  valid-oas-example-in-content: false
+  valid-oas-example-in-parameters: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: node_js
 node_js:
   - "10"
 before_script:
-  - npm install -g speccy@0.9.0
+  - npm install -g @stoplight/spectral
 script:
   - bin/validate-specs.sh

--- a/bin/validate-specs.sh
+++ b/bin/validate-specs.sh
@@ -1,17 +1,7 @@
 #!/usr/bin/env bash
 HAS_FAILURE=0
 
-COMMAND="speccy lint"
-# We don't have tags in every OAS
-COMMAND="$COMMAND -s openapi-tags"
-# Some operations don't need to be grouped
-COMMAND="$COMMAND -s operation-tags"
-# Sometimes we set default and example to the same value. We should fix this in the future
-COMMAND="$COMMAND -s default-and-example-are-redundant"
-# Our tag order is respected when rendering in the sidebar. We don't want them alphabetical
-COMMAND="$COMMAND -s openapi-tags-alphabetical"
-# There's an issue that means file-based refs trigger this rule incorrectly
-COMMAND="$COMMAND -s reference-no-other-properties"
+COMMAND="spectral lint -v"
 
 DOCS=$1
 


### PR DESCRIPTION
# Description

Move from our existing [speccy](https://speccy.io/) to [spectral](https://github.com/stoplightio/spectral). The main reasons for the move:

* Spectral is more actively developed and supported
* Spectral has out-of-the-box validation (some of which I've turned off for now)
* It supports adding custom rulesets so we'd be able to add more opinionated checks in line with our API standards effort