### PR TITLE
Reinstate numbers updates

### DIFF
--- a/definitions/numbers.yml
+++ b/definitions/numbers.yml
@@ -36,6 +36,8 @@ paths:
         - $ref: '#/components/parameters/size'
         - $ref: '#/components/parameters/pattern'
         - $ref: '#/components/parameters/search_pattern'
+        - $ref: '#/components/parameters/has_application'
+        - $ref: '#/components/parameters/application_id'
       responses:
         '200':
           description: OK
@@ -230,6 +232,27 @@ components:
           - 1
           - 2
       example: 1
+    has_application:
+      name: has_application
+      required: false
+      in: query
+      description: |
+        Set this optional field to `true` to restrict your results to numbers
+        associated with an application (any application). Set to `false` to
+        find all numbers not associated with any application. Omit the field
+        to avoid filtering on whether or not the number is assigned to an
+        application.
+      schema:
+        type: boolean
+      example: false
+    application_id:
+      name: application_id
+      required: false
+      in: query
+      description: The application that you want to return the numbers for.
+      schema:
+        type: string
+      example: 'aaaaaaaa-bbbb-cccc-dddd-0123456789ab'
     country:
       name: country
       in: query

--- a/definitions/numbers.yml
+++ b/definitions/numbers.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Numbers API
-  version: 1.0.9
+  version: 1.0.10
   description: >-
     The Numbers API enables you to manage your existing numbers and buy new virtual numbers for
     use with Nexmo's APIs. Further information is here: <https://developer.nexmo.com/numbers/overview>


### PR DESCRIPTION
# Description

Numbers API has new filters to make it easier to find numbers that are (or are not!) associated with applications

# New 

Added new `has_application` and `application_id` filters to the Numbers API

# Checklist

- [x] version number incremented (in the `info` section of the spec)
