### PR TITLE
Change VBC licensing to termsOfService

### DIFF
--- a/definitions/vonage-business-cloud/account.yml
+++ b/definitions/vonage-business-cloud/account.yml
@@ -5,55 +5,52 @@ info:
   title: Account API
   description: Retrieve information about accounts.
   contact:
-    name: 'Account API'
-    url: 'https://businesssupport.vonage.com/contactus'
-  license:
-    name: 'Vonage'
-    url: 'https://www.vonage.com/business/legal-policy-center/business-cloud/tos'
+    name: "Account API"
+    url: "https://businesssupport.vonage.com/contactus"
+  termsOfService: "https://www.vonage.com/business/legal-policy-center/business-cloud/tos"
 
 servers:
-- url: 'https://api.vonage.com/t/vbc.prod/provisioning'  
+  - url: "https://api.vonage.com/t/vbc.prod/provisioning"
 paths:
-
-  '/api/accounts/{account_id}':
+  "/api/accounts/{account_id}":
     get:
       operationId: AccountCtrl.getAccountServicesByAccountID
       parameters:
-        - $ref: '#/components/parameters/AccountID'
+        - $ref: "#/components/parameters/AccountID"
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AccountHalResponse'
-        '404':
+                $ref: "#/components/schemas/AccountHalResponse"
+        "404":
           description: Account not found
       security:
         - bearerAuth: []
       summary: Get account data by ID
 
-  '/api/accounts/{account_id}/locations':
+  "/api/accounts/{account_id}/locations":
     get:
       operationId: AccountCtrl.getLocationsByAccountID
       parameters:
-        - $ref: '#/components/parameters/AccountID'
+        - $ref: "#/components/parameters/AccountID"
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LocationsHalResponse'
+                $ref: "#/components/schemas/LocationsHalResponse"
       security:
         - bearerAuth: []
       summary: Get account locations data by account ID
 
-  '/api/accounts/{account_id}/locations/{location_id}':
+  "/api/accounts/{account_id}/locations/{location_id}":
     get:
       operationId: AccountCtrl.getLocationByID
       parameters:
-        - $ref: '#/components/parameters/AccountID'
+        - $ref: "#/components/parameters/AccountID"
         - in: path
           name: location_id
           required: true
@@ -62,13 +59,13 @@ paths:
           description: The location ID
           example: 123456
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LocationHalResponse'
-        '404':
+                $ref: "#/components/schemas/LocationHalResponse"
+        "404":
           description: Location not found
       security:
         - bearerAuth: []
@@ -80,7 +77,6 @@ components:
       type: http
       scheme: bearer
       bearerFormat: OAuth
-
 
   parameters:
     AccountID:
@@ -122,49 +118,48 @@ components:
       properties:
         href:
           type: string
-      description: URL to the last page of records                                
+      description: URL to the last page of records
     Links:
-      type: object    
+      type: object
       properties:
         first:
-          $ref: '#/components/schemas/FirstHref'
-        prev:       
-          $ref: '#/components/schemas/PrevHref'
-        self:       
-          $ref: '#/components/schemas/SelfHref'
-        next:       
-          $ref: '#/components/schemas/NextHref'
-        last:       
-          $ref: '#/components/schemas/LastHref'          
+          $ref: "#/components/schemas/FirstHref"
+        prev:
+          $ref: "#/components/schemas/PrevHref"
+        self:
+          $ref: "#/components/schemas/SelfHref"
+        next:
+          $ref: "#/components/schemas/NextHref"
+        last:
+          $ref: "#/components/schemas/LastHref"
 
     Address:
-      type: object    
+      type: object
       properties:
         address_1:
           type: string
-          example: '123 Example Street'
+          example: "123 Example Street"
           description: Street portion of the address
         address_2:
           type: string
-          example: 'Apt. 456'
+          example: "Apt. 456"
           description: Additional address information
         country:
           type: string
-          example: 'US'
+          example: "US"
           description: Country code
         state:
           type: string
-          example: 'NJ'
+          example: "NJ"
           description: State/Province code
         city:
           type: string
-          example: 'Holmdel'
+          example: "Holmdel"
           description: City name
         postal_code:
           type: string
-          example: '07733'
+          example: "07733"
           description: Postal code
-
 
     Account:
       properties:
@@ -174,53 +169,53 @@ components:
           description: Unique identifier of the account
         name:
           type: string
-          example: 'Vonage'
+          example: "Vonage"
           description: Name of the account
         status:
           type: string
-          example: 'ACTIVE'
+          example: "ACTIVE"
           description: Status of the account
         address:
-          $ref: '#/components/schemas/Address'
+          $ref: "#/components/schemas/Address"
       type: object
 
     AccountEmbeddedObject:
       type: object
       properties:
         data:
-          $ref: '#/components/schemas/Account'
+          $ref: "#/components/schemas/Account"
       description: Account object
 
     AddressWithTimeZone:
-      type: object    
+      type: object
       properties:
         address_1:
           type: string
-          example: '123 Example Street'
+          example: "123 Example Street"
           description: Street portion of the address
         address_2:
           type: string
-          example: 'Apt. 456'
+          example: "Apt. 456"
           description: Additional address information
         country:
           type: string
-          example: 'US'
+          example: "US"
           description: Country code
         state:
           type: string
-          example: 'NJ'
+          example: "NJ"
           description: State/Province code
         city:
           type: string
-          example: 'Holmdel'
+          example: "Holmdel"
           description: City name
         postal_code:
           type: string
-          example: '07733'
+          example: "07733"
           description: Postal code
         time_zone:
           type: string
-          example: 'America/New York'
+          example: "America/New York"
           description: Time zone
 
     Location:
@@ -232,35 +227,35 @@ components:
           description: Unique identifier of the location
         name:
           type: string
-          example: 'Headquarters'
+          example: "Headquarters"
           description: Name of the location
         address:
-          $ref: '#/components/schemas/AddressWithTimeZone'
-    
+          $ref: "#/components/schemas/AddressWithTimeZone"
+
     LocationsEmbeddedObject:
       type: object
       properties:
         data:
           items:
-            $ref: '#/components/schemas/Location'
+            $ref: "#/components/schemas/Location"
           type: array
       description: Collection of location objects
 
     LocationEmbeddedObject:
-      type: object    
+      type: object
       properties:
         data:
-          $ref: '#/components/schemas/Location'
+          $ref: "#/components/schemas/Location"
       description: Location object
 
     AccountHalResponse:
       type: object
       properties:
-        page_size:         
+        page_size:
           type: number
           example: 100
           description: Number of records per page
-        page:                  
+        page:
           type: number
           example: 1
           description: Current page number
@@ -270,21 +265,21 @@ components:
           description: Total number of pages
         total_items:
           type: number
-          example: 100        
+          example: 100
           description: Total number of records
         _links:
-          $ref: '#/components/schemas/Links'
+          $ref: "#/components/schemas/Links"
         _embedded:
-          $ref: '#/components/schemas/AccountEmbeddedObject'        
-    
+          $ref: "#/components/schemas/AccountEmbeddedObject"
+
     LocationHalResponse:
       type: object
       properties:
-        page_size:         
+        page_size:
           type: number
           example: 100
           description: Number of records per page
-        page:                  
+        page:
           type: number
           example: 1
           description: Current page number
@@ -294,20 +289,20 @@ components:
           description: Total number of pages
         total_items:
           type: number
-          example: 100        
+          example: 100
           description: Total number of records
         _links:
-          $ref: '#/components/schemas/Links'
+          $ref: "#/components/schemas/Links"
         _embedded:
-          $ref: '#/components/schemas/LocationEmbeddedObject'
+          $ref: "#/components/schemas/LocationEmbeddedObject"
 
     LocationsHalResponse:
       type: object
       properties:
-        page_size:         
+        page_size:
           type: number
           example: 100
-        page:                  
+        page:
           type: number
           example: 1
         total_pages:
@@ -315,11 +310,8 @@ components:
           example: 10
         total_items:
           type: number
-          example: 100              
+          example: 100
         _links:
-          $ref: '#/components/schemas/Links'
+          $ref: "#/components/schemas/Links"
         _embedded:
-          $ref: '#/components/schemas/LocationsEmbeddedObject'
-      
-
-  
+          $ref: "#/components/schemas/LocationsEmbeddedObject"

--- a/definitions/vonage-business-cloud/account.yml
+++ b/definitions/vonage-business-cloud/account.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: 1.11.7
+  version: 1.11.8
   title: Account API
   description: Retrieve information about accounts.
   contact:

--- a/definitions/vonage-business-cloud/extension.yml
+++ b/definitions/vonage-business-cloud/extension.yml
@@ -5,21 +5,18 @@ info:
   title: Extension API
   description: Retrieve information about extensions.
   contact:
-    name: 'Extension API'
-    url: 'https://businesssupport.vonage.com/contactus'
-  license:
-    name: 'Vonage'
-    url: 'https://www.vonage.com/business/legal-policy-center/business-cloud/tos'
+    name: "Extension API"
+    url: "https://businesssupport.vonage.com/contactus"
+  termsOfService: "https://www.vonage.com/business/legal-policy-center/business-cloud/tos"
 
 servers:
-- url: 'https://api.vonage.com/t/vbc.prod/provisioning'
+  - url: "https://api.vonage.com/t/vbc.prod/provisioning"
 paths:
-
-  '/api/accounts/{account_id}/extensions':
+  "/api/accounts/{account_id}/extensions":
     get:
       operationId: ExtensionCtrl.getAccountExtensions
       parameters:
-        - $ref: '#/components/parameters/AccountID'
+        - $ref: "#/components/parameters/AccountID"
         - in: query
           name: page_size
           required: false
@@ -47,43 +44,43 @@ paths:
           schema:
             type: string
           description: Filter by phone number
-          example: '14155550100'
+          example: "14155550100"
         - in: query
           name: login_name
           required: false
           schema:
             type: string
           description: Filter by login name
-          example: 'jsmith'
+          example: "jsmith"
         - in: query
           name: email
           required: false
           schema:
             type: string
           description: Filter by email address
-          example: 'john.smith@example.com'
+          example: "john.smith@example.com"
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EndUserRouteHalResponse'
-        '400':
+                $ref: "#/components/schemas/EndUserRouteHalResponse"
+        "400":
           description: Invalid parameters given
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ValidationErrorsResponse'
+                $ref: "#/components/schemas/ValidationErrorsResponse"
       security:
         - bearerAuth: []
       summary: Get account extensions data by account ID
 
-  '/api/accounts/{account_id}/extensions/{extension_number}':
+  "/api/accounts/{account_id}/extensions/{extension_number}":
     get:
       operationId: ExtensionCtrl.getAccountExtensionByID
       parameters:
-        - $ref: '#/components/parameters/AccountID'
+        - $ref: "#/components/parameters/AccountID"
         - in: path
           name: extension_number
           required: true
@@ -92,18 +89,18 @@ paths:
           description: The extension number
           example: 789
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EndUserRouteHalResponse'
-        '404':
+                $ref: "#/components/schemas/EndUserRouteHalResponse"
+        "404":
           description: Extension not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
       security:
         - bearerAuth: []
       summary: Get extension data by account ID and extension number
@@ -132,95 +129,95 @@ components:
           type: string
       description: URL to the first page of records
     PrevHref:
-      type: object    
+      type: object
       properties:
         href:
           type: string
       description: URL to the previous page of records
     SelfHref:
-      type: object    
+      type: object
       properties:
         href:
           type: string
       description: URL to the current page of records
     NextHref:
-      type: object    
+      type: object
       properties:
         href:
           type: string
       description: URL to the next page of records
     LastHref:
-      type: object    
+      type: object
       properties:
         href:
           type: string
       description: URL to the last page of records
 
     Links:
-      type: object    
+      type: object
       properties:
         first:
-          $ref: '#/components/schemas/FirstHref'
+          $ref: "#/components/schemas/FirstHref"
         prev:
-          $ref: '#/components/schemas/PrevHref'
+          $ref: "#/components/schemas/PrevHref"
         self:
-          $ref: '#/components/schemas/SelfHref'
+          $ref: "#/components/schemas/SelfHref"
         next:
-          $ref: '#/components/schemas/NextHref'
+          $ref: "#/components/schemas/NextHref"
 
     BasicUser:
-      type: object    
+      type: object
       properties:
         email:
           type: string
           description: Email address of the user
-          example: 'john.smith@example.com'
+          example: "john.smith@example.com"
         login_name:
           type: string
           description: Login name of the user
-          example: 'jsmith'
+          example: "jsmith"
         first_name:
           type: string
           description: First name of the user
-          example: 'John'
+          example: "John"
         last_name:
           type: string
           description: Last name of the user
-          example: 'Smith'
+          example: "Smith"
 
     DID:
-      type: object    
+      type: object
       properties:
         phone_number:
           type: string
           description: Phone number
-          example: '14155550100'
+          example: "14155550100"
         custom_tag:
           type: string
           description: Custom tag associated with the phone number
-          example: 'My Tag'
+          example: "My Tag"
 
     Line:
-      type: object    
+      type: object
       properties:
         handset_name:
           type: string
           description: Name of the handset
-          example: 'line1-VH1234567'
+          example: "line1-VH1234567"
         sip_id:
           type: string
           description: SIP identifier of the handset
-          example: 'VH1234567'
+          example: "VH1234567"
 
     EndUserRoute:
-      type: object    
+      type: object
       properties:
         extension_number:
           type: string
           description: Extension number
-          example: '789'
+          example: "789"
         user:
-          $ref: '#/components/schemas/BasicUser'
+          $ref: "#/components/schemas/BasicUser"
         location_id:
           type: number
           description: Unique identifier of the assigned location
@@ -236,36 +233,36 @@ components:
         caller_id:
           type: string
           description: Caller ID of the extension
-          example: 'John Smith'
+          example: "John Smith"
         block_caller_id:
           type: boolean
           description: Block Caller ID status of the extension
           example: false
         dids:
           items:
-            $ref: '#/components/schemas/DID'
+            $ref: "#/components/schemas/DID"
           type: array
           description: Collection of phone numbers assigned to the extension
         extension_handsets:
           items:
-            $ref: '#/components/schemas/Line'
+            $ref: "#/components/schemas/Line"
           type: array
           description: Collection of handsets assigned to the extension
 
     EndUserRouteEmbeddedObject:
-      type: object    
+      type: object
       properties:
         data:
-          $ref: '#/components/schemas/EndUserRoute'
+          $ref: "#/components/schemas/EndUserRoute"
 
     EndUserRouteHalResponse:
-      type: object    
+      type: object
       properties:
-        page_size:         
+        page_size:
           type: number
           example: 10
           description: Number of records per page
-        page:                  
+        page:
           type: number
           example: 1
           description: Current page number
@@ -275,15 +272,15 @@ components:
           description: Total number of pages
         total_items:
           type: number
-          example: 100        
+          example: 100
           description: Total number of records
         _links:
-          $ref: '#/components/schemas/Links'
+          $ref: "#/components/schemas/Links"
         _embedded:
-          $ref: '#/components/schemas/EndUserRouteEmbeddedObject'
+          $ref: "#/components/schemas/EndUserRouteEmbeddedObject"
 
     ErrorResponse:
-      type: object    
+      type: object
       properties:
         msg:
           description: Error message
@@ -293,7 +290,7 @@ components:
           type: number
 
     ValidationErrorsResponse:
-      type: object    
+      type: object
       properties:
         status:
           description: Error status code
@@ -306,12 +303,12 @@ components:
           type: string
         invalid_parameters:
           items:
-            $ref: '#/components/schemas/DetailedInvalidParam'
+            $ref: "#/components/schemas/DetailedInvalidParam"
           description: Invalid parameters and their reason for failing
           type: array
 
     DetailedInvalidParam:
-      type: object    
+      type: object
       properties:
         name:
           type: string

--- a/definitions/vonage-business-cloud/extension.yml
+++ b/definitions/vonage-business-cloud/extension.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: 1.11.7
+  version: 1.11.8
   title: Extension API
   description: Retrieve information about extensions.
   contact:

--- a/definitions/vonage-business-cloud/user.yml
+++ b/definitions/vonage-business-cloud/user.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: 1.11.7
+  version: 1.11.8
   title: User API
   description: Retrieve information about users.
   contact:

--- a/definitions/vonage-business-cloud/user.yml
+++ b/definitions/vonage-business-cloud/user.yml
@@ -5,21 +5,18 @@ info:
   title: User API
   description: Retrieve information about users.
   contact:
-    name: 'User API'
-    url: 'https://businesssupport.vonage.com/contactus'
-  license:
-    name: 'Vonage'
-    url: 'https://www.vonage.com/business/legal-policy-center/business-cloud/tos'
+    name: "User API"
+    url: "https://businesssupport.vonage.com/contactus"
+  termsOfService: "https://www.vonage.com/business/legal-policy-center/business-cloud/tos"
 
 servers:
-- url: 'https://api.vonage.com/t/vbc.prod/provisioning'
+  - url: "https://api.vonage.com/t/vbc.prod/provisioning"
 paths:
-
-  '/api/accounts/{account_id}/users':
+  "/api/accounts/{account_id}/users":
     get:
       operationId: UserCtrl.getUsers
       parameters:
-        - $ref: '#/components/parameters/AccountID'
+        - $ref: "#/components/parameters/AccountID"
         - in: query
           name: page_size
           required: false
@@ -40,50 +37,50 @@ paths:
           schema:
             type: string
           description: Filter by first name
-          example: 'John'
+          example: "John"
         - in: query
           name: last_name
           required: false
           schema:
             type: string
           description: Filter by last name
-          example: 'Smith'
+          example: "Smith"
         - in: query
           name: login_name
           required: false
           schema:
             type: string
           description: Filter by login name
-          example: 'jsmith'          
+          example: "jsmith"
         - in: query
           name: email
           required: false
           schema:
             type: string
           description: Filter by email address
-          example: 'john.smith@example.com'
+          example: "john.smith@example.com"
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UsersHalResponse'
-        '400':
+                $ref: "#/components/schemas/UsersHalResponse"
+        "400":
           description: Invalid parameters given
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ValidationErrorsResponse'                
+                $ref: "#/components/schemas/ValidationErrorsResponse"
       security:
         - bearerAuth: []
       summary: Get account users data by account ID
 
-  '/api/accounts/{account_id}/users/{user_id}':
+  "/api/accounts/{account_id}/users/{user_id}":
     get:
       operationId: UserCtrl.getUserByID
       parameters:
-        - $ref: '#/components/parameters/AccountID'
+        - $ref: "#/components/parameters/AccountID"
         - in: path
           name: user_id
           required: true
@@ -91,18 +88,18 @@ paths:
             type: number
           description: The ID of the user
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserHalResponse'
-        '404':
+                $ref: "#/components/schemas/UserHalResponse"
+        "404":
           description: User not found
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: "#/components/schemas/ErrorResponse"
       security:
         - bearerAuth: []
       summary: Get user data by account ID and user ID
@@ -131,123 +128,123 @@ components:
           type: string
       description: URL to the first page of records
     PrevHref:
-      type: object    
+      type: object
       properties:
         href:
           type: string
       description: URL to the previous page of records
     SelfHref:
-      type: object    
+      type: object
       properties:
         href:
           type: string
       description: URL to the current page of records
     NextHref:
-      type: object    
+      type: object
       properties:
         href:
           type: string
       description: URL to the next page of records
     LastHref:
-      type: object    
+      type: object
       properties:
         href:
           type: string
       description: URL to the last page of records
 
     Links:
-      type: object    
+      type: object
       properties:
         first:
-          $ref: '#/components/schemas/FirstHref'
+          $ref: "#/components/schemas/FirstHref"
         prev:
-          $ref: '#/components/schemas/PrevHref'
+          $ref: "#/components/schemas/PrevHref"
         self:
-          $ref: '#/components/schemas/SelfHref'
+          $ref: "#/components/schemas/SelfHref"
         next:
-          $ref: '#/components/schemas/NextHref'
+          $ref: "#/components/schemas/NextHref"
 
     Contact:
-      type: object    
+      type: object
       properties:
         type:
           type: string
           description: Contact type
-          example: 'Home'
+          example: "Home"
         value:
           type: string
           description: Contact value
-          example: '14155550100'
+          example: "14155550100"
 
     UserExtension:
-      type: object    
+      type: object
       properties:
         dids:
           items:
-            $ref: '#/components/schemas/DID'
+            $ref: "#/components/schemas/DID"
           type: array
           description: Collection of phone numbers assigned to the extension
         extension_number:
           type: string
           description: Extension number
-          example: '789'
+          example: "789"
 
     User:
-      type: object    
+      type: object
       properties:
         email:
           type: string
           description: Email address of the user
-          example: 'john.smith@example.com'
+          example: "john.smith@example.com"
         login_name:
           type: string
           description: Login name of the user
-          example: 'jsmith'
+          example: "jsmith"
         first_name:
           type: string
           description: First name of the user
-          example: 'John'
+          example: "John"
         last_name:
           type: string
           description: Last name of the user
-          example: 'Smith'
+          example: "Smith"
         id:
           type: number
           description: Unique identifier of the user
           example: 1234567
         contact_numbers:
           items:
-            $ref: '#/components/schemas/Contact'
+            $ref: "#/components/schemas/Contact"
           type: array
           description: Collection of contact objects
         extensions:
           items:
-            $ref: '#/components/schemas/UserExtension'
+            $ref: "#/components/schemas/UserExtension"
           type: array
           description: Collection of extension objects
 
     UsersEmbeddedObject:
-      type: object    
+      type: object
       properties:
         data:
           items:
-            $ref: '#/components/schemas/User'
+            $ref: "#/components/schemas/User"
           type: array
 
     UserEmbeddedObject:
-      type: object    
+      type: object
       properties:
         data:
-          $ref: '#/components/schemas/User'
+          $ref: "#/components/schemas/User"
 
     UserHalResponse:
-      type: object    
+      type: object
       properties:
-        page_size:         
+        page_size:
           type: number
           example: 10
           description: Number of records per page
-        page:                  
+        page:
           type: number
           example: 1
           description: Current page number
@@ -257,21 +254,21 @@ components:
           description: Total number of pages
         total_items:
           type: number
-          example: 100        
+          example: 100
           description: Total number of records
         _links:
-          $ref: '#/components/schemas/Links'
+          $ref: "#/components/schemas/Links"
         _embedded:
-          $ref: '#/components/schemas/UserEmbeddedObject'
+          $ref: "#/components/schemas/UserEmbeddedObject"
 
     UsersHalResponse:
-      type: object    
+      type: object
       properties:
-        page_size:         
+        page_size:
           type: number
           example: 10
           description: Number of records per page
-        page:                  
+        page:
           type: number
           example: 1
           description: Current page number
@@ -281,27 +278,27 @@ components:
           description: Total number of pages
         total_items:
           type: number
-          example: 100        
+          example: 100
           description: Total number of records
         _links:
-          $ref: '#/components/schemas/Links'
+          $ref: "#/components/schemas/Links"
         _embedded:
-          $ref: '#/components/schemas/UsersEmbeddedObject'
+          $ref: "#/components/schemas/UsersEmbeddedObject"
 
     DID:
-      type: object    
+      type: object
       properties:
         phone_number:
           type: string
           description: Phone number
-          example: '14155550100'
+          example: "14155550100"
         custom_tag:
           type: string
           description: Custom tag associated with the phone number
           example: My Tag
 
     ErrorResponse:
-      type: object    
+      type: object
       properties:
         msg:
           description: Error message
@@ -311,7 +308,7 @@ components:
           type: number
 
     ValidationErrorsResponse:
-      type: object    
+      type: object
       properties:
         status:
           description: Error status code
@@ -324,7 +321,7 @@ components:
           type: string
         invalid_parameters:
           items:
-            $ref: '#/components/schemas/DetailedInvalidParam'
+            $ref: "#/components/schemas/DetailedInvalidParam"
           description: Invalid parameters and their reason for failing
           type: array
 


### PR DESCRIPTION
# Description

The URL in the `license` field actually points to Terms of Service. Identify it as such in the OAS by using `termsOfService` field instead.

# Fixes

* Licensing details now reflected in `termsOfService`

# Checklist

- [X] version number incremented (in the `info` section of the spec)
