### PR TITLE
Remove rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'rake'
 gem 'nexmo-oas-renderer', '~> 0.6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,7 +190,6 @@ PLATFORMS
 
 DEPENDENCIES
   nexmo-oas-renderer (~> 0.6.1)
-  rake
 
 BUNDLED WITH
    2.0.2

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,0 @@
-begin
-  require 'rspec/core/rake_task'
-  RSpec::Core::RakeTask.new(:spec)
-rescue LoadError
-end
-
-task :default => :spec


### PR DESCRIPTION
Removes the Rakefile and the rake gem dependency.

Rake doesn't appear to be used for anything—there aren't any rake tasks defined, and the travis validation script is using bash/node.