### PR TITLE
Added missing secret parameter

### DIFF
--- a/definitions/subaccounts.yml
+++ b/definitions/subaccounts.yml
@@ -628,6 +628,9 @@ components:
         name:
           type: string
           example: 'Subaccount department A'
+        secret:
+          type: string
+          example: 'Password123'
         use_primary_account_balance:
           type: boolean
           example: false


### PR DESCRIPTION
When creating the subaccount, the primary account should be able to set a custom secret for this subaccount. The code supports it, bu the documentation does not reflect this.

# Description

<!--

The following will be used in our release notes and public changelog. Communicate well!

Example:

# New 

* Added new `/foobar/sync` endpoint to toggle widget status
* The `GET /v1/calls` endpoint now supports a `to` query parameter to filter calls to a single number

# Fixes

* Add HTTP 401 and 403 error code documentation to the `/v1/calls` endpoint
-->

# Checklist

- [ ] version number incremented (in the `info` section of the spec)
