### PR TITLE
Scope GH actions to the correct branches/events

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,5 +1,7 @@
-on: pull_request
 name: PR Edited
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
 jobs:
   createReviewApp:
     name: Create Review App

--- a/.github/workflows/push-commit-push.yml
+++ b/.github/workflows/push-commit-push.yml
@@ -1,5 +1,8 @@
-on: push
 name: Commit Push
+on:
+  push:
+    branches:
+      - master
 jobs:
   build:
     name: nexmo/github-actions/submodule-auto-pr@master

--- a/.github/workflows/push-openapi-release.yml
+++ b/.github/workflows/push-openapi-release.yml
@@ -1,5 +1,8 @@
-on: push
 name: OpenAPI Release
+on:
+  push:
+    branches:
+      - master
 jobs:
   releaseOAS:
     name: Release OAS


### PR DESCRIPTION
This makes our Github Actions only run on the correct events as neutral exit codes aren't a thing any more