### PR TITLE
Override base URL for CS Record operation

### DIFF
--- a/definitions/conversation.yml
+++ b/definitions/conversation.yml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers:
   - url: 'https://api.nexmo.com/beta'
 info:
-  version: 1.7.1
+  version: 1.7.2
   title: Nexmo Conversation API
   description: 'The Nexmo Conversation API enables you to build conversation features where communication can take place across multiple mediums including IP Messaging, PSTN Voice, SMS and WebRTC Audio and Video. The context of the conversations is maintained though each communication event taking place within a conversation, no matter the medium.'
   contact:
@@ -166,6 +166,9 @@ paths:
         '200':
           $ref: '#/components/responses/SuccessEmptyJSON'
   '/conversations/{conversation_id}/record':
+    servers:
+      - url: 'https://api.nexmo.com/v1'
+        description: Override base path for the PUT /conversations/{conversation_id}/record operation
     parameters:
       - $ref: '#/components/parameters/conversation_id'
     put:


### PR DESCRIPTION
# Description

# Fixes

* Override the base URL for the Conversation service `/record` endpoint to be the correct endpoint for this service. 

# Checklist

- [x] version number incremented (in the `info` section of the spec)
