### PR TITLE
Updated description of the callback field

### DIFF
--- a/definitions/reports.yml
+++ b/definitions/reports.yml
@@ -4,7 +4,7 @@ info:
   title: Nexmo Reports API
   description: >
     Nexmo's Reports API allows you to request a report of activity on your Nexmo account.<br>
-    On average the Reports API takes 5 - 10 minutes to generate 1 million records. We recommend to request reports up to a maximum of 20 million records by setting the start and end dates accordingly.<br>
+    On average the Reports API takes 5 - 10 minutes to generate 1 million records. Nexmo recommends requesting only reports of up to a maximum of 20 million records, by setting the start and end dates accordingly.<br>
     Reports are generated as CSV files compressed in zip archives.
   contact:
     name: Nexmo.com
@@ -419,7 +419,7 @@ components:
       default: false
     callback_url:
       type: string
-      description: URL to send a callback upon completion of the report. This POST callback contains the same information as the response to the [Get status of report](https://developer.nexmo.com/api/reports#get-report).
+      description: URL to send a callback upon completion of the report. This POST callback contains the same information as the response to [Get status of report](/api/reports#get-report).
       format: uri
       example: "https://requestb.in/12345"
     date_start:

--- a/definitions/reports.yml
+++ b/definitions/reports.yml
@@ -419,7 +419,7 @@ components:
       default: false
     callback_url:
       type: string
-      description: URL to send a callback upon completion of the report.
+      description: URL to send a callback upon completion of the report. This POST callback contains the same information as the response to the [Get status of report](https://developer.nexmo.com/api/reports#get-report).
       format: uri
       example: "https://requestb.in/12345"
     date_start:


### PR DESCRIPTION
Updated description of the callback URL field

# Description

<!--

The following will be used in our release notes and public changelog. Communicate well!

Example:

# New 

* Added new `/foobar/sync` endpoint to toggle widget status
* The `GET /v1/calls` endpoint now supports a `to` query parameter to filter calls to a single number

# Fixes

* Add HTTP 401 and 403 error code documentation to the `/v1/calls` endpoint
-->

# Checklist

- [ ] version number incremented (in the `info` section of the spec)
