### PR TITLE
Pricing API OAS3 spec

### DIFF
--- a/definitions/pricing.yml
+++ b/definitions/pricing.yml
@@ -1,8 +1,5 @@
 openapi: 3.0.0
 servers:
-  # Added by API Auto Mocking Plugin
-  - description: SwaggerHub API Auto Mocking
-    url: https://virtserver.swaggerhub.com/tbedford/Pricing/0.0.1
   - url: "https://rest.nexmo.com"
 info:
   version: "0.0.1"

--- a/definitions/pricing.yml
+++ b/definitions/pricing.yml
@@ -297,7 +297,7 @@ components:
         type:
           type: string
           example: "mobile"
-          description: "TBD mobile description"
+          description: "The type of network: mobile or landline."
         price:
           type: string
           example: "0.00590000"

--- a/definitions/pricing.yml
+++ b/definitions/pricing.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 servers:
-  - url: 'https://rest.nexmo.com'
+  - url: "https://rest.nexmo.com"
 info:
   version: "0.0.1"
   title: Pricing API
@@ -8,11 +8,11 @@ info:
     The API to retrieve pricing information.
 
     Please note the Pricing API is rate limited to one request per second.
-    
+
   contact:
     name: Nexmo DevRel
     email: devrel@nexmo.com
-    url: 'https://developer.nexmo.com/'
+    url: "https://developer.nexmo.com/"
 paths:
   /account/get-pricing/outbound/{type}:
     get:
@@ -49,18 +49,18 @@ paths:
           description: A two letter [country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). For example, `CA`.
           required: true
           schema:
-            type: string            
+            type: string
       responses:
-        '200':
+        "200":
           description: Pricing information for a specific country.
           content:
             application/json:
               schema:
-                  $ref: '#/components/schemas/PricingCountryResponse'
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '404':
-          $ref: '#/components/responses/NotFoundError'
+                $ref: "#/components/schemas/PricingCountryResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
   /account/get-full-pricing/outbound/{type}:
     get:
       summary: Retrieve outbound pricing for all countries.
@@ -91,16 +91,16 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Pricing response
           content:
             application/json:
               schema:
-                  $ref: '#/components/schemas/PricingCountriesResponse'
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '404':
-          $ref: '#/components/responses/NotFoundError'
+                $ref: "#/components/schemas/PricingCountriesResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
   /account/get-prefix-pricing/outbound/{type}:
     get:
       summary: Retrieve outbound pricing for a specific dialing prefix.
@@ -136,18 +136,18 @@ paths:
           description: "The numerical dialing prefix to look up pricing for. Examples include 44, 1 and so on."
           required: true
           schema:
-            type: string            
+            type: string
       responses:
-        '200':
+        "200":
           description: Pricing countries response
           content:
             application/json:
               schema:
-                  $ref: '#/components/schemas/PricingCountriesResponse'
-        '401':
-          $ref: '#/components/responses/UnauthorizedError'
-        '404':
-          $ref: '#/components/responses/NotFoundError'
+                $ref: "#/components/schemas/PricingCountriesResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
 components:
   securitySchemes:
     basicAuth:
@@ -167,60 +167,60 @@ components:
             properties:
               currency:
                 type: string
-                example: 'EUR'
+                example: "EUR"
               code:
                 type: string
-                example: '401'
+                example: "401"
               error-code-label:
                 type: string
-                example: 'authentication failed'
+                example: "authentication failed"
     NotFoundError:
       description: The page you requested was not found
       content:
         text/html:
-          example: '404 - Page does not exist'
+          example: "404 - Page does not exist"
   schemas:
     PricingCountryResponse:
       properties:
         countryCode:
-          example: 'CA'
+          example: "CA"
           type: string
           description: >-
             Two letter country code.
         countryName:
           type: string
-          example: 'Canada'
+          example: "Canada"
           description: >-
-           Readable country name.
+            Readable country name.
         countryDisplayName:
           type: string
-          example: 'Canada'
+          example: "Canada"
           description: >-
-           Readable country name.
+            Readable country name.
         currency:
           type: string
-          example: 'EUR'
+          example: "EUR"
           description: >-
-           The currency that your account is being billed in (by default: Euros—EUR). Changeable via the Dashboard to US Dollars—USD.
+            The currency that your account is being billed in (by default: Euros—EUR). Changeable via the Dashboard to US Dollars—USD.
         defaultPrice:
           type: string
-          example: '0.00620000'
+          example: "0.00620000"
           description: >-
-           The default price.
+            The default price.
         dialingPrefix:
           type: string
-          example: '1'
+          example: "1"
           description: >-
-           The dialling prefix.
+            The dialling prefix.
         networks:
-          type: array   
-          description: An array of network objects 
+          type: array
+          description: An array of network objects
           items:
-            $ref: '#/components/schemas/NetworkObject'
+            $ref: "#/components/schemas/NetworkObject"
     PricingCountriesResponse:
       properties:
         count:
-          example: '243'
+          example: "243"
           type: string
           description: >-
             The number of countries retrieved.
@@ -229,40 +229,40 @@ components:
           description: >-
             A list of countries.
           items:
-            $ref: '#/components/schemas/CountryObject'
+            $ref: "#/components/schemas/CountryObject"
     CountryObject:
       type: object
       properties:
         countryName:
           type: string
-          example: 'Canada'
+          example: "Canada"
           description: >-
-           Readable country name.
+            Readable country name.
         countryDisplayName:
           type: string
-          example: 'Canada'
+          example: "Canada"
           description: >-
-           Readable country name.
+            Readable country name.
         currency:
           type: string
-          example: 'EUR'
+          example: "EUR"
           description: >-
-           The currency that your account is being billed in (by default: Euros—EUR). Changeable via the Dashboard to US Dollars—USD.
+            The currency that your account is being billed in (by default: Euros—EUR). Changeable via the Dashboard to US Dollars—USD.
         defaultPrice:
           type: string
-          example: '0.00620000'
+          example: "0.00620000"
           description: >-
-           The default price.
+            The default price.
         dialingPrefix:
           type: string
-          example: '1'
+          example: "1"
           description: >-
-           The dialling prefix.
+            The dialling prefix.
         networks:
-          type: array   
+          type: array
           description: An array of network objects
           items:
-            $ref: '#/components/schemas/NetworkObject'
+            $ref: "#/components/schemas/NetworkObject"
     NetworkObject:
       type: object
       properties:
@@ -270,7 +270,7 @@ components:
           type: string
           example: "mobile"
         price:
-          type: string 
+          type: string
           example: "0.00590000"
         currency:
           type: string

--- a/definitions/pricing.yml
+++ b/definitions/pricing.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 servers:
-# Added by API Auto Mocking Plugin
+  # Added by API Auto Mocking Plugin
   - description: SwaggerHub API Auto Mocking
     url: https://virtserver.swaggerhub.com/tbedford/Pricing/0.0.1
   - url: "https://rest.nexmo.com"
@@ -173,17 +173,17 @@ components:
       description: You made too many requests. The API is rate limited to one request per second.
       content:
         text/html:
-          schema: 
+          schema:
             type: string
           example: "429 - Too many requests"
     NotFoundError:
       description: The page you requested was not found
       content:
         text/html:
-          schema: 
+          schema:
             type: string
           example: "404 - Page does not exist"
-  
+
   parameters:
     api_key:
       name: api_key
@@ -191,7 +191,7 @@ components:
       description: Your Nexmo API key.
       required: true
       schema:
-        type: string  
+        type: string
     api_secret:
       name: api_secret
       in: query
@@ -297,22 +297,28 @@ components:
         type:
           type: string
           example: "mobile"
+          description: "TBD mobile description"
         price:
           type: string
           example: "0.00590000"
+          description: "The cost to send a message or make a call to this network"
         currency:
           type: string
           example: "EUR"
+          description: "The currency used for prices for this network."
         mcc:
           type: string
           example: "302"
+          description: "The [Mobile Country Code](https://en.wikipedia.org/wiki/Mobile_country_code) of the operator."
         mnc:
           type: string
           example: "530"
+          description: "The Mobile Network Code of the operator."
         networkCode:
           type: string
           example: "302530"
+          description: "The Mobile Country Code and Mobile Network Code combined to give a unique reference for the operator."
         networkName:
           type: string
           example: "Keewaytinook Okimakanak"
-  
+          description: "The company/organisational name of the operator."

--- a/definitions/pricing.yml
+++ b/definitions/pricing.yml
@@ -1,5 +1,8 @@
 openapi: 3.0.0
 servers:
+# Added by API Auto Mocking Plugin
+  - description: SwaggerHub API Auto Mocking
+    url: https://virtserver.swaggerhub.com/tbedford/Pricing/0.0.1
   - url: "https://rest.nexmo.com"
 info:
   version: "0.0.1"
@@ -25,25 +28,9 @@ paths:
       security:
         - basicAuth: []
       parameters:
-        - name: type
-          in: path
-          description: "The type of service you wish to retrieve data about: either `sms`, `sms-transit` or `voice`."
-          required: true
-          example: sms
-          schema:
-            type: string
-        - name: api_key
-          in: query
-          description: Your Nexmo API key.
-          required: true
-          schema:
-            type: string
-        - name: api_secret
-          in: query
-          description: Your Nexmo API secret.
-          required: true
-          schema:
-            type: string
+        - $ref: "#/components/parameters/type"
+        - $ref: "#/components/parameters/api_key"
+        - $ref: "#/components/parameters/api_secret"
         - name: country
           in: query
           description: A two letter [country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). For example, `CA`.
@@ -57,10 +44,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PricingCountryResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestError"
         "401":
           $ref: "#/components/responses/UnauthorizedError"
         "404":
           $ref: "#/components/responses/NotFoundError"
+        "429":
+          $ref: "#/components/responses/TooManyRequestsError"
   /account/get-full-pricing/outbound/{type}:
     get:
       summary: Retrieve outbound pricing for all countries.
@@ -72,24 +63,9 @@ paths:
       security:
         - basicAuth: []
       parameters:
-        - name: type
-          in: path
-          description: "The type of service you wish to retrieve data about: either `sms`, `sms-transit` or `voice`."
-          required: true
-          schema:
-            type: string
-        - name: api_key
-          in: query
-          description: Your Nexmo API key.
-          required: true
-          schema:
-            type: string
-        - name: api_secret
-          in: query
-          description: Your Nexmo API secret.
-          required: true
-          schema:
-            type: string
+        - $ref: "#/components/parameters/type"
+        - $ref: "#/components/parameters/api_key"
+        - $ref: "#/components/parameters/api_secret"
       responses:
         "200":
           description: Pricing response
@@ -97,10 +73,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PricingCountriesResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestError"
         "401":
           $ref: "#/components/responses/UnauthorizedError"
         "404":
           $ref: "#/components/responses/NotFoundError"
+        "429":
+          $ref: "#/components/responses/TooManyRequestsError"
+
   /account/get-prefix-pricing/outbound/{type}:
     get:
       summary: Retrieve outbound pricing for a specific dialing prefix.
@@ -112,25 +93,9 @@ paths:
       security:
         - basicAuth: []
       parameters:
-        - name: type
-          in: path
-          description: "The type of service you wish to retrieve data about: either `sms`, `sms-transit` or `voice`."
-          required: true
-          example: sms
-          schema:
-            type: string
-        - name: api_key
-          in: query
-          description: Your Nexmo API key.
-          required: true
-          schema:
-            type: string
-        - name: api_secret
-          in: query
-          description: Your Nexmo API secret.
-          required: true
-          schema:
-            type: string
+        - $ref: "#/components/parameters/type"
+        - $ref: "#/components/parameters/api_key"
+        - $ref: "#/components/parameters/api_secret"
         - name: prefix
           in: query
           description: "The numerical dialing prefix to look up pricing for. Examples include 44, 1 and so on."
@@ -144,10 +109,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PricingCountriesResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestError"
         "401":
           $ref: "#/components/responses/UnauthorizedError"
         "404":
           $ref: "#/components/responses/NotFoundError"
+        "429":
+          $ref: "#/components/responses/TooManyRequestsError"
 components:
   securitySchemes:
     basicAuth:
@@ -174,11 +143,70 @@ components:
               error-code-label:
                 type: string
                 example: "authentication failed"
+    BadRequestError:
+      description: Bad request. You probably provided an invalid parameter.
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - type
+              - error_title
+              - invalid_parameters
+            properties:
+              type:
+                type: string
+                example: "BAD_REQUEST"
+              error_title:
+                type: string
+                example: "Bad Request"
+              invalid_parameters:
+                type: object
+                properties:
+                  parameter:
+                    type: string
+                    example: "country"
+                  message:
+                    type: string
+                    example: "Is required"
+    TooManyRequestsError:
+      description: You made too many requests. The API is rate limited to one request per second.
+      content:
+        text/html:
+          schema: 
+            type: string
+          example: "429 - Too many requests"
     NotFoundError:
       description: The page you requested was not found
       content:
         text/html:
+          schema: 
+            type: string
           example: "404 - Page does not exist"
+  
+  parameters:
+    api_key:
+      name: api_key
+      in: query
+      description: Your Nexmo API key.
+      required: true
+      schema:
+        type: string  
+    api_secret:
+      name: api_secret
+      in: query
+      description: Your Nexmo API secret.
+      required: true
+      schema:
+        type: string
+    type:
+      name: type
+      in: path
+      description: "The type of service you wish to retrieve data about: either `sms`, `sms-transit` or `voice`."
+      required: true
+      example: sms
+      schema:
+        type: string
   schemas:
     PricingCountryResponse:
       properties:
@@ -287,3 +315,4 @@ components:
         networkName:
           type: string
           example: "Keewaytinook Okimakanak"
+  

--- a/definitions/pricing.yml
+++ b/definitions/pricing.yml
@@ -1,8 +1,5 @@
 openapi: 3.0.0
 servers:
-# Added by API Auto Mocking Plugin
-  - description: SwaggerHub API Auto Mocking
-    url: https://virtserver.swaggerhub.com/tbedford/Pricing/0.0.1
   - url: 'https://rest.nexmo.com'
 info:
   version: "0.0.1"

--- a/definitions/pricing.yml
+++ b/definitions/pricing.yml
@@ -201,7 +201,7 @@ components:
           type: string
           example: "EUR"
           description: >-
-            The currency that your account is being billed in (by default: Euros—EUR). Changeable via the Dashboard to US Dollars—USD.
+            The currency that your account is being billed in (by default `Euros—EUR`). Can change in the Dashboard to US Dollars—USD.
         defaultPrice:
           type: string
           example: "0.00620000"
@@ -247,7 +247,7 @@ components:
           type: string
           example: "EUR"
           description: >-
-            The currency that your account is being billed in (by default: Euros—EUR). Changeable via the Dashboard to US Dollars—USD.
+            The currency that your account is being billed in (by default `Euros—EUR`). Can change in the Dashboard to US Dollars—USD.
         defaultPrice:
           type: string
           example: "0.00620000"

--- a/definitions/pricing.yml
+++ b/definitions/pricing.yml
@@ -1,0 +1,292 @@
+openapi: 3.0.0
+servers:
+# Added by API Auto Mocking Plugin
+  - description: SwaggerHub API Auto Mocking
+    url: https://virtserver.swaggerhub.com/tbedford/Pricing/0.0.1
+  - url: 'https://rest.nexmo.com'
+info:
+  version: "0.0.1"
+  title: Pricing API
+  description: >-
+    The API to retrieve pricing information.
+
+    Please note the Pricing API is rate limited to one request per second.
+    
+  contact:
+    name: Nexmo DevRel
+    email: devrel@nexmo.com
+    url: 'https://developer.nexmo.com/'
+paths:
+  /account/get-pricing/outbound/{type}:
+    get:
+      summary: Retrieve outbound pricing for a specific country.
+      operationId: retrievePricingCountry
+      description: >
+        Retrieves the pricing information based on the specified country.
+      tags:
+        - Pricing
+      security:
+        - basicAuth: []
+      parameters:
+        - name: type
+          in: path
+          description: "The type of service you wish to retrieve data about: either `sms`, `sms-transit` or `voice`."
+          required: true
+          example: sms
+          schema:
+            type: string
+        - name: api_key
+          in: query
+          description: Your Nexmo API key.
+          required: true
+          schema:
+            type: string
+        - name: api_secret
+          in: query
+          description: Your Nexmo API secret.
+          required: true
+          schema:
+            type: string
+        - name: country
+          in: query
+          description: A two letter [country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). For example, `CA`.
+          required: true
+          schema:
+            type: string            
+      responses:
+        '200':
+          description: Pricing information for a specific country.
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/PricingCountryResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+  /account/get-full-pricing/outbound/{type}:
+    get:
+      summary: Retrieve outbound pricing for all countries.
+      operationId: retrievePricingAllCountries
+      description: >
+        Retrieves the pricing information for all countries.
+      tags:
+        - Pricing
+      security:
+        - basicAuth: []
+      parameters:
+        - name: type
+          in: path
+          description: "The type of service you wish to retrieve data about: either `sms`, `sms-transit` or `voice`."
+          required: true
+          schema:
+            type: string
+        - name: api_key
+          in: query
+          description: Your Nexmo API key.
+          required: true
+          schema:
+            type: string
+        - name: api_secret
+          in: query
+          description: Your Nexmo API secret.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Pricing response
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/PricingCountriesResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+  /account/get-prefix-pricing/outbound/{type}:
+    get:
+      summary: Retrieve outbound pricing for a specific dialing prefix.
+      operationId: retrievePrefixPricing
+      description: >
+        Retrieves the pricing information based on the dialing prefix.
+      tags:
+        - Pricing
+      security:
+        - basicAuth: []
+      parameters:
+        - name: type
+          in: path
+          description: "The type of service you wish to retrieve data about: either `sms`, `sms-transit` or `voice`."
+          required: true
+          example: sms
+          schema:
+            type: string
+        - name: api_key
+          in: query
+          description: Your Nexmo API key.
+          required: true
+          schema:
+            type: string
+        - name: api_secret
+          in: query
+          description: Your Nexmo API secret.
+          required: true
+          schema:
+            type: string
+        - name: prefix
+          in: query
+          description: "The numerical dialing prefix to look up pricing for. Examples include 44, 1 and so on."
+          required: true
+          schema:
+            type: string            
+      responses:
+        '200':
+          description: Pricing countries response
+          content:
+            application/json:
+              schema:
+                  $ref: '#/components/schemas/PricingCountriesResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+  responses:
+    UnauthorizedError:
+      description: You did not provide valid credentials
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - currency
+              - code
+              - error-code-label
+            properties:
+              currency:
+                type: string
+                example: 'EUR'
+              code:
+                type: string
+                example: '401'
+              error-code-label:
+                type: string
+                example: 'authentication failed'
+    NotFoundError:
+      description: The page you requested was not found
+      content:
+        text/html:
+          example: '404 - Page does not exist'
+  schemas:
+    PricingCountryResponse:
+      properties:
+        countryCode:
+          example: 'CA'
+          type: string
+          description: >-
+            Two letter country code.
+        countryName:
+          type: string
+          example: 'Canada'
+          description: >-
+           Readable country name.
+        countryDisplayName:
+          type: string
+          example: 'Canada'
+          description: >-
+           Readable country name.
+        currency:
+          type: string
+          example: 'EUR'
+          description: >-
+           The currency that your account is being billed in (by default: Euros—EUR). Changeable via the Dashboard to US Dollars—USD.
+        defaultPrice:
+          type: string
+          example: '0.00620000'
+          description: >-
+           The default price.
+        dialingPrefix:
+          type: string
+          example: '1'
+          description: >-
+           The dialling prefix.
+        networks:
+          type: array   
+          description: An array of network objects 
+          items:
+            $ref: '#/components/schemas/NetworkObject'
+    PricingCountriesResponse:
+      properties:
+        count:
+          example: '243'
+          type: string
+          description: >-
+            The number of countries retrieved.
+        countries:
+          type: array
+          description: >-
+            A list of countries.
+          items:
+            $ref: '#/components/schemas/CountryObject'
+    CountryObject:
+      type: object
+      properties:
+        countryName:
+          type: string
+          example: 'Canada'
+          description: >-
+           Readable country name.
+        countryDisplayName:
+          type: string
+          example: 'Canada'
+          description: >-
+           Readable country name.
+        currency:
+          type: string
+          example: 'EUR'
+          description: >-
+           The currency that your account is being billed in (by default: Euros—EUR). Changeable via the Dashboard to US Dollars—USD.
+        defaultPrice:
+          type: string
+          example: '0.00620000'
+          description: >-
+           The default price.
+        dialingPrefix:
+          type: string
+          example: '1'
+          description: >-
+           The dialling prefix.
+        networks:
+          type: array   
+          description: An array of network objects
+          items:
+            $ref: '#/components/schemas/NetworkObject'
+    NetworkObject:
+      type: object
+      properties:
+        type:
+          type: string
+          example: "mobile"
+        price:
+          type: string 
+          example: "0.00590000"
+        currency:
+          type: string
+          example: "EUR"
+        mcc:
+          type: string
+          example: "302"
+        mnc:
+          type: string
+          example: "530"
+        networkCode:
+          type: string
+          example: "302530"
+        networkName:
+          type: string
+          example: "Keewaytinook Okimakanak"


### PR DESCRIPTION
# Description

Adds first version of Pricing API. Known issue: HTML responses do not render.

# New 

* Added first version of Pricing OAS3 specification.

# Checklist

- [x] version number incremented (in the `info` section of the spec) (Initial version, 0.0.1)
