### PR TITLE
Update conversation.yml

### DIFF
--- a/definitions/conversation.yml
+++ b/definitions/conversation.yml
@@ -720,9 +720,9 @@ components:
         - start
         - stop
     event_url:
-      type: string
+      type: array
       format: url
-      example: 'https://example.com/event'
+      example: '["https://example.com/event"]'
       description: The webhook endpoint where recording progress events are sent to.
     event_method:
       type: string


### PR DESCRIPTION
Corrected `event_url` from String to Array.

# Description

<!--

The following will be used in our release notes and public changelog. Communicate well!

# Fixes

* Corrected `event_url` from String to Array in the record conversation endpoint.
-->

