### PR TITLE
Revert "Update conversation.yml (#205)"

### DIFF
--- a/definitions/conversation.yml
+++ b/definitions/conversation.yml
@@ -720,9 +720,9 @@ components:
         - start
         - stop
     event_url:
-      type: array
+      type: string
       format: url
-      example: '["https://example.com/event"]'
+      example: 'https://example.com/event'
       description: The webhook endpoint where recording progress events are sent to.
     event_method:
       type: string


### PR DESCRIPTION
This reverts commit 9bae5ad438022241d8fb3110f6ada04d1dde4572.

I am reverting my conversation.yml because while it builds it does not render.


# Description

<!--

The following will be used in our release notes and public changelog. Communicate well!

Example:

# New 

* Added new `/foobar/sync` endpoint to toggle widget status
* The `GET /v1/calls` endpoint now supports a `to` query parameter to filter calls to a single number

# Fixes

* Add HTTP 401 and 403 error code documentation to the `/v1/calls` endpoint
-->

# Checklist

- [ ] version number incremented (in the `info` section of the spec)
