### PR TITLE
Remove schemas as renderer will render description.

### DIFF
--- a/definitions/pricing.yml
+++ b/definitions/pricing.yml
@@ -168,18 +168,8 @@ components:
                     example: "Is required"
     TooManyRequestsError:
       description: You made too many requests. The API is rate limited to one request per second.
-      content:
-        text/html:
-          schema:
-            type: string
-          example: "429 - Too many requests"
     NotFoundError:
       description: The page you requested was not found
-      content:
-        text/html:
-          schema:
-            type: string
-          example: "404 - Page does not exist"
 
   parameters:
     api_key:


### PR DESCRIPTION
# Description

The schema blocks in the HTML error code sections were not required, and the changes were rejected by NDP. This PR removes those unnecessary sections.

I've tested this branch against NDP via PR #2154.

# New 

* OAS3 version of Pricing API.

# Checklist

- [x] version number incremented (in the `info` section of the spec) **Was already incremented in previous version not published.**
