### PR TITLE
Add target_api_key field for numbers

### DIFF
--- a/definitions/numbers.yml
+++ b/definitions/numbers.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Numbers API
-  version: 1.0.13
+  version: 1.0.14
   description: >-
     The Numbers API enables you to manage your existing numbers and buy new virtual numbers for
     use with Nexmo's APIs. Further information is here: <https://developer.nexmo.com/numbers/overview>
@@ -363,9 +363,12 @@ components:
           description: The two character country code in ISO 3166-1 alpha-2 format
         msisdn:
           type: string
-
           example: "447700900000"
           description: An available inbound virtual number.
+        target_api_key:
+          type: string
+          example: "abc123"
+          description: If api_key is one of a partner account, the API key of one of its subaccounts the operation should be acted on
       required:
         - country
         - msisdn

--- a/definitions/numbers.yml
+++ b/definitions/numbers.yml
@@ -367,7 +367,7 @@ components:
           description: An available inbound virtual number.
         target_api_key:
           type: string
-          example: "abc123"
+          example: "1a2345b7"
           description: If api_key is one of a partner account, the API key of one of its subaccounts the operation should be acted on
       required:
         - country

--- a/definitions/numbers.yml
+++ b/definitions/numbers.yml
@@ -368,7 +368,7 @@ components:
         target_api_key:
           type: string
           example: "1a2345b7"
-          description: If api_key is one of a partner account, the API key of one of its subaccounts the operation should be acted on
+          description: If you’d like to perform an action on a subaccount, provide the `api_key` of that account here. If you’d like to perform an action on your own account, you do not need to provide this field.
       required:
         - country
         - msisdn


### PR DESCRIPTION
# Description

# New 
* Add new `target_api_key` field when buying or cancelling a number using Numbers API

# Checklist

- [x] version number incremented (in the `info` section of the spec)
