### PR TITLE
update keyword

### DIFF
--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -270,8 +270,8 @@ components:
           example: 'text'
         keyword:
           type: string
-          description: The first word in the message body. This is typically used with short codes.
-          example: Hello
+          description: The first word in the message body. Converted to upper case.
+          example: HELLO
         message-timestamp:
           description: The time when Nexmo started to push this Delivery Receipt to your webhook endpoint.
           type: string


### PR DESCRIPTION
Corrected keyword definition in inbound sms webhook, we always convert this string to UPPER CASE and its sent regardless of shortcode use so not really relevant.


