### PR TITLE
Added correct Base URL

### DIFF
--- a/definitions/vonage-business-cloud/vgis.yml
+++ b/definitions/vonage-business-cloud/vgis.yml
@@ -15,6 +15,8 @@ tags:
   - name: Webhooks
     description: Webhooks are external URLs which subscribe to receive events via HTTP POST for a
       specified set of events.
+servers:
+  - url: "https://api.vonage.com/t/vbc.prod/vis/v1"
 paths:
   /self:
     get:

--- a/definitions/vonage-business-cloud/vgis.yml
+++ b/definitions/vonage-business-cloud/vgis.yml
@@ -1085,8 +1085,6 @@ paths:
           description: Bad Gateway
       x-auth-type: Application & Application User
       x-throttling-tier: Unlimited
-servers:
-  - url: https://api.vonage.com/vgis
 components:
   schemas:
     Error:


### PR DESCRIPTION
The Base URL for the VIS api is wrong (https://api.vonage.com/vgis_ it looks as if it wasn't set in the OAS spec so I'm not quite sure where the renderer was picking it up from, this is the correct URL