### PR TITLE
OTT-2868: Update messages API to include Viber MO

### DIFF
--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -154,7 +154,7 @@ components:
         status:
           type: string
           example: delivered
-          description: The status of the message. The `read` message status is only available for `messenger` and `whatsapp`.
+          description: The status of the message. The `read` message status is available for `messenger`, `whatsapp` and `viber`.
           enum:
             - submitted
             - delivered
@@ -215,10 +215,13 @@ components:
                 - messenger
                 - mms
                 - whatsapp
+                - viber_service_msg
             id:
               type: string
-              description: The ID of the recipient.
-              example: '0123456678901234'
+              description: |
+                **Messenger** or **Viber**: 
+              The ID of the recipient.
+              example: '01234567'
             number:
               type: string
               minLength: 1
@@ -240,6 +243,7 @@ components:
                 - messenger
                 - mms
                 - whatsapp
+                - viber_service_msg
             id:
               type: string
               description: The ID of the sender.
@@ -250,7 +254,7 @@ components:
               maxLength: 50
               example: '447700900000'
               description: |
-                **WhatsApp** or **MMS**: 
+                **WhatsApp** or **MMS** or **Viber**:
                 The phone number of the message sender in the [E.164](https://en.wikipedia.org/wiki/E.164) format.
         timestamp:
           type: string
@@ -268,7 +272,7 @@ components:
                   description: |
                     The type of message being received. 
                     **whatsapp** and **messenger** supports `text`, `image`, `audio`, `video`, `file` and `location`. WhatsApp maximum inbound size is 64mb.
-                    **mms** supports `image`. 
+                    **mms** supports `image`. **viber** supports `text`.
                   example: 'text'
                   enum:
                     - text
@@ -489,8 +493,6 @@ components:
             The URL of the image attachment. 
 
             **messenger** and **mms** supports .jpg, .jpeg, .png and .gif.
-
-            **viber_service_msg** supports .jpg .jpeg, and .png.
 
             **whatsapp** supports .jpg .jpeg, and .png.
           minLength: 10

--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: 0.3.5
+  version: 0.3.6
   title: Messages API
   description: 'The Messaging API is a new API that consolidates all messaging channels. It encapsulates a user (developer) from having to use multiple APIs to interact with our various channels such as SMS, MMS, Viber, Facebook Messenger, etc. The API normalises information across all channels to abstracted to, from and content. This API is currently in Beta.'
   contact:

--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: 0.3.4
+  version: 0.3.5
   title: Messages API
   description: 'The Messaging API is a new API that consolidates all messaging channels. It encapsulates a user (developer) from having to use multiple APIs to interact with our various channels such as SMS, MMS, Viber, Facebook Messenger, etc. The API normalises information across all channels to abstracted to, from and content. This API is currently in Beta.'
   contact:
@@ -218,10 +218,10 @@ components:
                 - viber_service_msg
             id:
               type: string
+              example: '01234567'
               description: |
                 **Messenger** or **Viber**: 
-              The ID of the recipient.
-              example: '01234567'
+                The ID of the recipient.
             number:
               type: string
               minLength: 1
@@ -272,7 +272,8 @@ components:
                   description: |
                     The type of message being received. 
                     **whatsapp** and **messenger** supports `text`, `image`, `audio`, `video`, `file` and `location`. WhatsApp maximum inbound size is 64mb.
-                    **mms** supports `image`. **viber** supports `text`.
+                    **mms** supports `image`.
+                    **viber** supports `text`.
                   example: 'text'
                   enum:
                     - text
@@ -378,7 +379,7 @@ components:
 
                 **Messenger**: supports `text`, `image`, `audio`, `video` and `file`.
 
-                **Viber Service Messages**: supports `image` and `text` and `custom`.
+                **Viber Service Messages**: supports `image`, `text` and `custom`.
 
                 **WhatsApp**: supports `template`, `text`, `image`, `audio`, `file`, `video` and `custom`. Maximum outbound media size is 64mb.
 
@@ -494,7 +495,7 @@ components:
 
             **messenger** and **mms** supports .jpg, .jpeg, .png and .gif.
 
-            **whatsapp** supports .jpg .jpeg, and .png.
+            **whatsapp** and **viber_service_msg** supports .jpg .jpeg, and .png.
           minLength: 10
           maxLength: 2000
           example: 'https://example.com/image.jpg'

--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: 0.3.6
+  version: 0.3.5
   title: Messages API
   description: 'The Messaging API is a new API that consolidates all messaging channels. It encapsulates a user (developer) from having to use multiple APIs to interact with our various channels such as SMS, MMS, Viber, Facebook Messenger, etc. The API normalises information across all channels to abstracted to, from and content. This API is currently in Beta.'
   contact:


### PR DESCRIPTION
OTT-2868: Update messages API to include Viber MO

# Description

<!--

IN PROGRESS: 

* Add Viber MO to API Spec

# Fixes

* Add HTTP 401 and 403 error code documentation to the `/v1/calls` endpoint
-->

# Checklist

- [x] version number incremented (in the `info` section of the spec)
