### PR TITLE
Be specific about the spectral version to use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: node_js
 node_js:
   - "10"
 before_script:
-  - npm install -g @stoplight/spectral
+  - npm install -g @stoplight/spectral@4.2.0
 script:
   - bin/validate-specs.sh


### PR DESCRIPTION
# Description

Add the version of `spectral` to the Travis config so that we don't get surprise upgrades that break the build! I've pinned to 4.2.0 for now.