### PR TITLE
Move to spectral 5.0

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,9 +1,12 @@
-extends: spectral:oas3
-rules: 
-  operation-tags: false
+extends: spectral:oas
+rules:
+  example-value-or-externalValue: false
+  oas3-unused-components-schema: false # needed by inter-file references e.g. Voice API
+  oas3-valid-content-schema-example: false
+  oas3-valid-oas-content-example: false
+  oas3-valid-oas-parameter-example: false
+  oas3-valid-parameter-schema-example: false
+  oas3-valid-schema-example: false
+  openapi-tags: false
   operation-description: false
-  valid-example-in-schemas: false
-  valid-schema-example-in-content: false
-  valid-schema-example-in-parameters: false
-  valid-oas-example-in-content: false
-  valid-oas-example-in-parameters: false
+  operation-tags: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: node_js
 node_js:
   - "10"
 before_script:
-  - npm install -g @stoplight/spectral@4.2.0
+  - npm install -g @stoplight/spectral@5.0.0
 script:
   - bin/validate-specs.sh

--- a/definitions/conversation.v2.yml
+++ b/definitions/conversation.v2.yml
@@ -650,3 +650,11 @@ components:
             href:
               type: string
               example: https://api.nexmo.com/beta2/users/USR-e46d9542-752a-4786-8f12-25a2e623a793
+
+tags:
+  - name: conversation
+    description: A conversation is a shared core component that Nexmo APIs rely on. Conversations happen over multiple mediums and and can have associated Users through Memberships.
+  - name: member
+    description: Memberships connect users with conversations. Each membership has one conversation and one user however a user can have many memberships to conversations just as conversations can have many members.
+  - name: event
+    description: 'Events are actions that occur within a conversation. Examples of this includes: Text events from members, or invite events from users'

--- a/definitions/conversation.yml
+++ b/definitions/conversation.yml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers:
   - url: 'https://api.nexmo.com/beta'
 info:
-  version: 1.7.4
+  version: 1.7.5
   title: Nexmo Conversation API
   description: 'The Nexmo Conversation API enables you to build conversation features where communication can take place across multiple mediums including IP Messaging, PSTN Voice, SMS and WebRTC Audio and Video. The context of the conversations is maintained though each communication event taking place within a conversation, no matter the medium.'
   contact:
@@ -1215,15 +1215,15 @@ security:
   - bearerAuth: []
 
 tags:
-  - name: Conversation
+  - name: conversation
     description: A conversation is a shared core component that Nexmo APIs rely on. Conversations happen over multiple mediums and and can have associated Users through Memberships.
-  - name: User
+  - name: user
     description: 'The concept of a user exists in Nexmo APIs, you can associate one with a user in your own application if you choose. A user can have multiple memberships to conversations and can communicate with other users through various different mediums.'
-  - name: Member
+  - name: member
     description: Memberships connect users with conversations. Each membership has one conversation and one user however a user can have many memberships to conversations just as conversations can have many members.
-  - name: Event
+  - name: event
     description: 'Events are actions that occur within a conversation. Examples of this includes: Text events from members, or invite events from users'
-  - name: Leg
+  - name: leg
     description: 'A leg can be a video call, IP call, or PSTN call that users participate in using multiple platforms. With this endpoint you can retrieve the details about all of the legs that took place in your application.'
-  - name: Rtc
+  - name: rtc
     description: Rtc actions. Any rtc action related (like starting a new rtc connection).


### PR DESCRIPTION
# Description

Spectral released a new version a few weeks ago which looks great especially as we start creating our own spectral rules. This PR switches to the updated ruleset configuration and makes some minor changes to that and to our specs to ensure that everything validates.


# Fixes

* Improves quality by using the newest version of the validation tool

# Checklist

- [x] version number incremented (in the `info` section of the spec)
