### PR TITLE
Add a spectral function to check format of parameter names

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,4 +1,5 @@
 extends: spectral:oas
+functions: [nexmo-property-name-underscores]
 rules:
   example-value-or-externalValue: false
   oas3-unused-components-schema: false # needed by inter-file references e.g. Voice API
@@ -10,3 +11,11 @@ rules:
   openapi-tags: false
   operation-description: false
   operation-tags: false
+
+  nexmo-property-name-underscores:
+    severity: warn
+    recommended: true
+    given: "$.paths.*.*.parameters.*"
+    then:
+      function: "nexmo-property-name-underscores"
+

--- a/functions/README.md
+++ b/functions/README.md
@@ -1,0 +1,5 @@
+# Functions
+
+These functions are for our [spectral](https://github.com/stoplightio/spectral) rules.
+
+**nexmo-property-name-underscores** checks our property names against the API standards. Basically: maximum one underscore, no hyphens, no CamelCase

--- a/functions/nexmo-property-name-underscores.js
+++ b/functions/nexmo-property-name-underscores.js
@@ -1,0 +1,25 @@
+// use with "$.paths.*.*.parameters.*"
+
+module.exports = (targetVal) => {
+    // more types of data structure will also be passed in here in future
+    return test_field(targetVal.name);
+}
+
+function test_field(field) {
+
+    // camelcase?
+    if (/[A-Z]/.test(field)) {
+        return [{message: "All variable names should be lower case (found " + field + ")"}];
+    }
+
+    // hypen?
+    if (/[-]/.test(field)) {
+        return [{message: "Property names must use underscores, not hyphens (found " + field + ")"}];
+    }
+
+    // multiple underscores?
+    if (field.split("_").length > 2) {
+        return [{message: "Property names may not have more than one underscore (found " + field + ")"}];
+    }
+
+};


### PR DESCRIPTION
# Description

Use a spectral custom function to check parameter naming.

# New 

* Add parameter format checking for API standards

# Checklist

- [ ] version number incremented (in the `info` section of the spec)
