### PR TITLE
Apply property naming check to response properties too

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -15,7 +15,14 @@ rules:
   nexmo-property-name-underscores:
     severity: warn
     recommended: true
-    given: "$.paths.*.*.parameters.*"
+    given: "$.paths.*.*.parameters.*.name"
+    then:
+      function: "nexmo-property-name-underscores"
+
+  nexmo-response-property-name-underscores:
+    severity: warn
+    recommended: true
+    given: "$..components.schemas.*.properties[*]~"
     then:
       function: "nexmo-property-name-underscores"
 

--- a/functions/nexmo-property-name-underscores.js
+++ b/functions/nexmo-property-name-underscores.js
@@ -1,8 +1,10 @@
 // use with "$.paths.*.*.parameters.*"
 
 module.exports = (targetVal) => {
-    // more types of data structure will also be passed in here in future
-    return test_field(targetVal.name);
+    if(typeof targetVal == "string") {
+        // it's the field name
+        return test_field(targetVal);
+    }
 }
 
 function test_field(field) {


### PR DESCRIPTION
# Description

A followup to #240 that also checks response field names fit our naming scheme.

# New 

* Improved consistency checking on response field names.

# Checklist

- [ ] version number incremented (in the `info` section of the spec)

^ specs not updated, so version number not updated.
