### PR TITLE
Update links to new page

### DIFF
--- a/definitions/external-accounts.yml
+++ b/definitions/external-accounts.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: 0.1.2
+  version: 0.1.3
   title: External Accounts
   description: 'The External Accounts API is used to manage accounts for Viber Service Messages, Facebook Messenger and Whatsapp for use in the [Messages](https://developer.nexmo.com/messages/overview) and [Dispatch](https://developer.nexmo.com/dispatch/overview) APIs.'
   x-label: Developer Preview

--- a/definitions/external-accounts.yml
+++ b/definitions/external-accounts.yml
@@ -38,7 +38,7 @@ paths:
                 access_token:
                   type: string
                   example: "myAccessToken"
-                  description: This is the Facebook Page token. You can obtain the token using one of the following methods:
+                  description: This is the Facebook Page token. You can obtain the token using one of the following methods
                     <ul>
                     <li>Use our tool to link a page to your Nexmo account [https://messenger.nexmo.com](https://messenger.nexmo.com)</li>
                     <li>Following the official [token reference](https://developers.facebook.com/docs/pages/access-tokens/)</li>

--- a/definitions/external-accounts.yml
+++ b/definitions/external-accounts.yml
@@ -40,7 +40,7 @@ paths:
                   example: "myAccessToken"
                   description: It is a Facebook Page token. There ways how to obtain the token
                     <ul>
-                    <li>Use our tool to link a page to your Nexmo account[https://static.nexmo.com/messenger/](https://static.nexmo.com/messenger/)</li>
+                    <li>Use our tool to link a page to your Nexmo account[https://messenger.nexmo.com](https://messenger.nexmo.com)</li>
                     <li>Following the official [token reference](https://developers.facebook.com/docs/pages/access-tokens/)</li>
                     </ul>
                 name:

--- a/definitions/external-accounts.yml
+++ b/definitions/external-accounts.yml
@@ -38,9 +38,9 @@ paths:
                 access_token:
                   type: string
                   example: "myAccessToken"
-                  description: It is a Facebook Page token. There ways how to obtain the token
+                  description: This is the Facebook Page token. You can obtain the token using one of the following methods:
                     <ul>
-                    <li>Use our tool to link a page to your Nexmo account[https://messenger.nexmo.com](https://messenger.nexmo.com)</li>
+                    <li>Use our tool to link a page to your Nexmo account [https://messenger.nexmo.com](https://messenger.nexmo.com)</li>
                     <li>Following the official [token reference](https://developers.facebook.com/docs/pages/access-tokens/)</li>
                     </ul>
                 name:
@@ -54,7 +54,7 @@ paths:
                   example: ["optionalApplicationId"]
                   minItems: 0
                   maxItems: 1
-                  description: It should contain a list of application IDs which should be linked to the account.
+                  description: Contains a list of application IDs which are linked to the account.
                     <ul>
                     <li>There is just one application allowed per an account.</li>
                     <li>The application type must be type "messages".</li>


### PR DESCRIPTION
# Fixes

* The link for the page to link Facebook and Nexmo accounts has been changed.

# Checklist

- [x] version number incremented (in the `info` section of the spec)
