### PR TITLE
Remove restriction on number of allowed underscores in field names

### DIFF
--- a/functions/nexmo-property-name-underscores.js
+++ b/functions/nexmo-property-name-underscores.js
@@ -18,10 +18,4 @@ function test_field(field) {
     if (/[-]/.test(field)) {
         return [{message: "Property names must use underscores, not hyphens (found " + field + ")"}];
     }
-
-    // multiple underscores?
-    if (field.split("_").length > 2) {
-        return [{message: "Property names may not have more than one underscore (found " + field + ")"}];
-    }
-
 };


### PR DESCRIPTION
# Description

Remove the check on multiple underscores as we're now going to allow them. This depends on the PR to the standards repo before we can merge this one https://github.com/Nexmo/api-standards/pull/11

# Fixes

* Update validation rules to match our new standard of unlimited underscores

# Checklist

- [ ] version number incremented (in the `info` section of the spec)

^ no, because I didn't change a spec