### PR TITLE
Remove nexmo-property-name-underscores from .spectral.yml

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -1,5 +1,4 @@
 extends: spectral:oas
-functions: [nexmo-property-name-underscores]
 rules:
   example-value-or-externalValue: false
   oas3-unused-components-schema: false # needed by inter-file references e.g. Voice API


### PR DESCRIPTION
# Description

Remove `nexmo-property-name-underscores` from the Spectral functions list as we don't use it anymore (in fact, it no longer exists)

# Checklist

- [ ] version number incremented (in the `info` section of the spec)

^ Not a definition change