### PR TITLE
Updated "message-count" to show as a string

### DIFF
--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -227,7 +227,7 @@ components:
         message-count:
           type: string
           description: The amount of messages in the request
-          example: 1
+          example: '1'
         messages:
           type: array
           items:


### PR DESCRIPTION
The value returned in message-count is a string, but it was displayed as an integer in the example. Updated to show as a string now.
