### PR TITLE
Add API key and signature fields to SMS spec

### DIFF
--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -406,12 +406,28 @@ components:
           example: '2001011400'
         err-code:
           type: string
-          description: The status of the request. Will be a non `0` value if there has been an error. See the [Delivery Receipt documentation](https://developer.nexmo.com/messaging/sms/guides/delivery-receipts#dlr-error-codes) for more details
+          description: The status of the request. Will be a non `0` value if there has been an error, or if the status is unknown. See the [Delivery Receipt documentation](https://developer.nexmo.com/messaging/sms/guides/delivery-receipts#dlr-error-codes) for more details
           example: '0'
+        api-key:
+          type: string
+          description: The API key that sent the SMS. This is useful when multiple accounts are sending webhooks to the same endpoint.
+          example: 'abcd1234'
         message-timestamp:
           description: The time when Nexmo started to push this Delivery Receipt to your webhook endpoint.
           type: string
           example: 2020-01-01 12:00:00
+        timestamp:
+          type: string
+          example: 1582650446
+          description: A timestamp in Unix (seconds since the epoch) format. _Only included if you have signatures enabled_
+        nonce:
+          type: string
+          example: ec11dd3e-1e7f-4db5-9467-82b02cd223b9
+          description: A random string to be used when calculating the signature. _Only included if you have signatures enabled_
+        sig:
+          type: string
+          example: 1A20E4E2069B609FDA6CECA9DE18D5CAFE99720DDB628BD6BE8B19942A336E1C
+          description: The signature to enable verification of the source of this webhook. Please see the [developer documentation for validating signatures](https://developer.nexmo.com/concepts/guides/signing-messages) for more information, or use one of our published SDKs. _Only included if you have signatures enabled_
 
 x-errors:
   "1":

--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -402,7 +402,7 @@ components:
             - unknown
         scts:
           type: string
-          description: When the DLR was recieved from the carrier in the following format `YYMMDDHHMM`. For example, `2001011400` is at `2020-01-01 14:00`
+          description: When the DLR was received from the carrier in the following format `YYMMDDHHMM`. For example, `2001011400` is at `2020-01-01 14:00`
           example: '2001011400'
         err-code:
           type: string

--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -205,7 +205,7 @@ components:
         message-count:
           type: string
           description: The amount of messages in the request
-          example: 1
+          example: "1"
         messages:
           type: array
           items:

--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: 1.0.6
+  version: 1.0.7
   title: SMS API
   description: With the Nexmo SMS API you can send SMS from your account and lookup messages both messages that you've sent as well as messages sent to your virtual numbers. Numbers are specified in E.164 format. More SMS API documentation is at <https://developer.nexmo.com/messaging/sms/overview>
   contact:
@@ -101,13 +101,13 @@ components:
           description: Your API secret. Required unless `sig` is provided
           example: abcdef0123456789
           type: string
-          minLength: 16
-          maxLength: 16
+          minLength: 6
+          maxLength: 32
         sig:
           description: The hash of the request parameters in alphabetical order, a timestamp and the signature secret. See [Signing Requests](/concepts/guides/signing-messages) for more details.
           type: string
           minLength: 16
-          maxLength: 16
+          maxLength: 60
         from:
           description: The name or number the message should be sent from. Alphanumeric senderID's are not supported in all countries, see [Global Messaging](https://developer.nexmo.com/messaging/sms/guides/global-messaging#country-specific-features) for more details. If alphanumeric, spaces will be ignored. Numbers are specified in E.164 format.
           type: string


### PR DESCRIPTION
# Description

We were missing a few fields that I observe when I get delivery receipts, and I found some data inconsistency when working with Prism

# New 

* Added API key and message signature fields to delivery receipts callback

# Fixes

* Data types, field length information and a very small typo

# Checklist

- [x] version number incremented (in the `info` section of the spec)
