### PR TITLE
Making search_pattern description a little clearer

### DIFF
--- a/definitions/numbers.yml
+++ b/definitions/numbers.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Numbers API
-  version: 1.0.15
+  version: 1.0.16
   description: >-
     The Numbers API enables you to manage your existing numbers and buy new virtual numbers for
     use with Nexmo's APIs. Further information is here: <https://developer.nexmo.com/numbers/overview>
@@ -226,7 +226,7 @@ components:
         The strategy you want to use for matching:
 
 
-        * `0` - Search for numbers that start with `pattern`
+        * `0` - Search for numbers that start with `pattern` (Note: all numbers are in E.164 format, so the starting pattern includes the country code, such as 1 for USA)
         * `1` - Search for numbers that contain `pattern`
         * `2` - Search for numbers that end with `pattern`
       schema:


### PR DESCRIPTION
Thinking that this description should perhaps change to note that the country code is inclusive for value `0` - for US developers, in particular, we tend to think in terms of our area codes (321, 201, 305, etc. . .) And as I stumbled on this one I think others might be confused by it as well.

# Description

<!--

The following will be used in our release notes and public changelog. Communicate well!

Example:

# New 

* Added new `/foobar/sync` endpoint to toggle widget status
* The `GET /v1/calls` endpoint now supports a `to` query parameter to filter calls to a single number

# Fixes

* Add HTTP 401 and 403 error code documentation to the `/v1/calls` endpoint
-->

# Checklist

- [x] version number incremented (in the `info` section of the spec)
