### PR TITLE
Experiment with new webhooks spec

### DIFF
--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -1,4 +1,4 @@
-openapi: "3.1.0"
+openapi: "3.0.3"
 info:
   version: 1.0.10
   title: SMS API
@@ -65,7 +65,7 @@ paths:
                 "200":
                   description: Your server returns this code if it accepts the callback
 
-webhooks:
+x-webhooks:
   inbound-sms:
     post:
       summary: Inbound SMS

--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -1,6 +1,6 @@
-openapi: "3.0.0"
+openapi: "3.1.0"
 info:
-  version: 1.0.9
+  version: 1.0.10
   title: SMS API
   description: With the SMS API you can send SMS from your account and lookup messages both messages that you've sent as well as messages sent to your virtual numbers. Numbers are specified in E.164 format. More SMS API documentation is at <https://developer.nexmo.com/messaging/sms/overview>
   contact:
@@ -64,26 +64,26 @@ paths:
               responses:
                 "200":
                   description: Your server returns this code if it accepts the callback
-x-webhooks:
+
+webhooks:
   inbound-sms:
-    "{$request.body#/callback}":
-      post:
-        summary: Inbound SMS
-        operationId: inbound-sms
-        x-example-path: "/webhooks/inbound-sms"
-        description: |
+    post:
+      summary: Inbound SMS
+      operationId: inbound-sms
+      x-example-path: "/webhooks/inbound-sms"
+      description: |
           If you rent one or more virtual numbers from Vonage, inbound messages to that number are sent to your [webhook endpoint](/concepts/guides/webhooks).
 
           When you receive an inbound message, you must send a 2xx response. If you do not send a 2xx response Vonage will resend the inbound message for the next 24 hours.
-        requestBody:
-          required: true
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/InboundMessage"
-        responses:
-          "200":
-            description: Your server returns this code if it accepts the callback
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InboundMessage'
+      responses:
+        '200':
+          description: Your server returns this code if it accepts the callback
 
 components:
   schemas:


### PR DESCRIPTION
# Description

The upcoming (hopefully!) version of OpenAPI v3.1 has "proper" support for webhooks, so this change updates the spec version and our own `x-webhooks` format to take advantage of the new `webhooks` section instead.

The build fails for now while we figure out how to update the validation tooling :)

# New 

* Bring the webhooks docs up to the new OAS 3.1 format

# Checklist

- [x] version number incremented (in the `info` section of the spec)
