### PR TITLE
To number is a string

### DIFF
--- a/definitions/developer/messages.yml
+++ b/definitions/developer/messages.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Message Search API
-  version: 1.0.3
+  version: 1.0.4
   description: >-
     The Messages API lets you retrieve messages you have sent via the SMS API by
     ID, as well as retrieve details of messages that were rejected.
@@ -238,7 +238,7 @@ components:
         to:
           type: string
           description: The phone number the message was sent to.
-          example: 447700900000
+          example: '447700900000'
         body:
           type: string
           description: The body of the message.


### PR DESCRIPTION
# Fixes

* `to` number is a string but was displaying as number in response examples.

# Checklist

- [x] version number incremented (in the `info` section of the spec)
