### PR TITLE
adding note for WhatsApp Template charecter restrictions

### DIFF
--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: 0.3.7
+  version: 0.3.8
   title: Messages API
   description: 'The Messaging API is a new API that consolidates all messaging channels. It encapsulates a user (developer) from having to use multiple APIs to interact with our various channels such as SMS, MMS, Viber, Facebook Messenger, etc. The API normalises information across all channels to abstracted to, from and content. This API is currently in Beta.'
   contact:

--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -573,10 +573,13 @@ components:
           example: 'Additional text to accompany the image.'
     TemplateProperty:
       type: object
+      x-nexmo-developer-collection-description-shown: true
+      description: |
+        > **Note**: WhatsApp templates are restricted to having 60 characters in the header and footer components, and 1024 characters in the body component
       properties:
         name:
           type: string
-          description: 'The name of the template. For WhatsApp use your Whatsapp namespace (available via Facebook Business Manager), followed by a colon `:` and the name of the template to use.'
+          description: 'The name of the template. For WhatsApp use your WhatsApp namespace (available via Facebook Business Manager), followed by a colon `:` and the name of the template to use.'
           example: 'WhatsApp_namespace:template_name'
         parameters:
           type: array

--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -420,14 +420,9 @@ components:
             file:
               $ref: '#/components/schemas/FileProperty'
             template:
-              $ref: '#/components/schemas/TemplateProperty'
-            # @TODO: Clarify requirements
-            # custom:
-            #   type: object
-            #   description: This is a highly experimental feature. To enable the user to send any type of Messenger message we have included a custom object. To use this feature include the original Messenger API payload from the message object onwards.
-            #   properties:
-            #     custom:
-            #       type: object
+              $ref: '#/components/schemas/TemplateProperty'            
+            custom:
+              $ref: '#/components/schemas/CustomProperty'
         viber_service_msg:
           type: object
           properties:
@@ -573,9 +568,6 @@ components:
           example: 'Additional text to accompany the image.'
     TemplateProperty:
       type: object
-      x-nexmo-developer-collection-description-shown: true
-      description: |
-        > **Note**: WhatsApp templates are restricted to having 60 characters in the header and footer components, and 1024 characters in the body component
       properties:
         name:
           type: string
@@ -613,6 +605,12 @@ components:
           type: string
           description: The name of the location attachment.
           example: 'Nexmo London'
+    CustomProperty:
+      type: object
+      x-nexmo-developer-collection-description-shown: true
+      description: |
+        Custom Content, used for such features as sending [Media Message Templates](https://developer.nexmo.com/messages/code-snippets/whatsapp/send-media-mtm) and [Link Buttons](https://developer.nexmo.com/messages/code-snippets/whatsapp/send-button-link) in WhatsApp
+        > **NOTE** WhatsApp templates are restricted to having 60 characters in each header and footer component. Additionally the Body component is restricted to 1024 characters
 
 x-errors:
   "1000":


### PR DESCRIPTION
# Description

OAS spec for Messages needs to be updated to reflect the new character restrictions on templates - these restrictions have been lifted from 160 chars total - to 60 chars in header / footer and 1024 chars in the body: https://developers.facebook.com/docs/whatsapp/business-management-api/message-templates/

# Checklist

- [x] version number incremented (in the `info` section of the spec)
