### PR TITLE
Voice API: number in EndpointPhone is required

### DIFF
--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: 1.2.5
+  version: 1.2.6
   title: Voice API
   description: The Voice API lets you create outbound calls, control in-progress calls
     and get information about historical calls. More information about the Voice API
@@ -695,6 +695,7 @@ components:
       type: object
       description: Connect to a Phone (PSTN) number
       required:
+        - number
         - type
       properties:
         type:


### PR DESCRIPTION
# Description

# New 

* Voice API describe the `number` attribute of the `EndpointPhone` object as required.

# Fixes

* If the field is not specified, the user gets this response:
```
{"type":400,"title":"Bad Request","invalid_parameters":[{"reason":"part of phone type and cannot be empty or NULL","name":"number"}]}                                                                                                          
```

# Checklist

- [x] version number incremented (in the `info` section of the spec)
