### PR TITLE
DEVX-2820 Updating Supported Talk Voice List

### DIFF
--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -831,54 +831,99 @@ components:
       type: string
       default: Kimberly
       enum:
-      - Salli
-      - Joey
-      - Naja
-      - Mads
-      - Marlene
-      - Hans
-      - Nicole
-      - Russell
+      - Aditi
+      - Agnieszka
+      - Alva
       - Amy
+      - Astrid
+      - Bianca
       - Brian
-      - Emma
-      - Geraint
-      - Gwyneth
-      - Raveena
+      - Carla
+      - Carmen
+      - Carmit
+      - Catarina
+      - Celine
+      - Cem
+      - Chantal
       - Chipmunk
+      - Conchita
+      - Cristiano
+      - Damayanti
+      - Dora
+      - Emma
+      - Empar
+      - Enrique
       - Eric
+      - Ewa
+      - Felipe
+      - Filiz
+      - Geraint
+      - Giorgio
+      - Gwyneth
+      - Hans
+      - Henrik
+      - Ines
+      - Ioana
+      - Iveta
       - Ivy
+      - Jacek
+      - Jan
       - Jennifer
+      - Joana
+      - Joanna
+      - Joey
+      - Jordi
       - Justin
+      - Kanya
+      - Karl
       - Kendra
       - Kimberly
-      - Conchita
-      - Enrique
-      - Penelope
-      - Miguel
-      - Chantal
-      - Celine
-      - Mathieu
-      - Dora
-      - Karl
-      - Carla
-      - Giorgio
+      - Laila
+      - Laura
+      - Lea
+      - Lekha
       - Liv
       - Lotte
-      - Ruben
-      - Agnieszka
-      - Jacek
-      - Ewa
-      - Jan
+      - Lucia
+      - Luciana
+      - Mads
+      - Maged
       - Maja
-      - Vitoria
-      - Ricardo
-      - Cristiano
-      - Ines
-      - Carmen
+      - Mariska
+      - Marlene
+      - Mathieu
+      - Matthew
       - Maxim
-      - Tatyana
-      - Astrid
-      - Filiz
+      - Mei-Jia
+      - Melina
+      - Mia
+      - Miguel
+      - Miren
       - Mizuki
+      - Montserrat
+      - Naja
+      - Nicole
+      - Nikos
+      - Nora
+      - Oskar
+      - Penelope
+      - Raveena
+      - Ricardo
+      - Ruben
+      - Russell
+      - Salli
+      - Satu
       - Seoyeon
+      - Sin-Ji
+      - Sora
+      - Takumi
+      - Tarik
+      - Tatyana
+      - Tessa
+      - Tian-Tian
+      - Vicki
+      - Vitoria
+      - Yelda
+      - Zeina
+      - Zhiyu
+      - Zuzana

--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: 1.2.6
+  version: 1.2.7
   title: Voice API
   description: The Voice API lets you create outbound calls, control in-progress calls
     and get information about historical calls. More information about the Voice API


### PR DESCRIPTION
See also DEVX-2821

# Description

<!--

The following will be used in our release notes and public changelog. Communicate well!

Example:

# New 

* Added new `/foobar/sync` endpoint to toggle widget status
* The `GET /v1/calls` endpoint now supports a `to` query parameter to filter calls to a single number

# Fixes

* Add HTTP 401 and 403 error code documentation to the `/v1/calls` endpoint
-->

Newly supported Text to Speech voices added to the list of possible values for `voice_name` parameter of `PUT /v1/calls/{uuid}/talk` operation.

# Checklist

- [x] version number incremented (in the `info` section of the spec)
