### PR TITLE
Whats app fallback deprecation

### DIFF
--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: 0.3.7
+  version: 0.3.8
   title: Messages API
   description: 'The Messaging API is a new API that consolidates all messaging channels. It encapsulates a user (developer) from having to use multiple APIs to interact with our various channels such as SMS, MMS, Viber, Facebook Messenger, etc. The API normalises information across all channels to abstracted to, from and content. This API is currently in Beta.'
   contact:

--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -467,11 +467,10 @@ components:
           type: object
           properties:
             policy:
-              description: 'Please note that WhatsApp will deprecate `fallback` policy in January 2020. There are two policies that you can specify when sending a Message Template: `deterministic` and `fallback`. `deterministic` — Deliver the Message Template in exactly the language and locale asked for. `fallback` — Deliver the Message Template in the language that matches users language/locale setting on device. If one can not be found, deliver using the specified fallback language.'
+              description: 'Please note that WhatsApp deprecated `fallback` policy in January 2020. Use of the fallback policy will result in a 1020 error in the status callback'
               type: string
               example: 'deterministic'
               enum:
-                - fallback
                 - deterministic
             locale:
               description: 'We are using the industry standard, BCP 47, for locales. So in your API call to the /messages API you will need to put “en-GB” and this will refer to the “en_GB” template for WhatsApp. A full list of the possible locales is available on [developers.facebook.com](https://developers.facebook.com/docs/whatsapp/message-templates/creation#translations).'


### PR DESCRIPTION
# Description

 Updates to the messages spec to reflect the deprecation of the fallback policy for WhatsApp

# Fixes

* removed fallback policy from enumeration and updated note to reflect a validation error will occur if it's sent

# Checklist

- [x] version number incremented (in the `info` section of the spec)
