### PR TITLE
Reports API fixes

### DIFF
--- a/definitions/reports.yml
+++ b/definitions/reports.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: 2.1.2
+  version: 2.1.3
   title: Nexmo Reports API
   description: |
     [Nexmo's Reports API](/reports/overview) allows you to request a report of activity on your Nexmo account.
@@ -76,7 +76,7 @@ paths:
           in: query
           schema:
             type: string
-          example: inbound
+          example: "aaaaaaaa-bbbb-cccc-dddd-0123456789ab"
         - name: date_start
           schema:
             type: string
@@ -84,10 +84,9 @@ paths:
           description: |
             ISO-8601 extended time zone offset or ISO-8601 UTC zone offset formatted date (format `yyyy-mm-ddThh:mm:ss[.sss]±hh:mm` or `yyyy-mm-ddThh:mm:ss[.sss]Z`) for when reports should begin. 
 
-            It filters on the time the API call was received by Nexmo and corresponds to the field date_received (date_start for Voice) in the report file. It is inclusive, i.e. the provided value is less than or equal to the value in the field date_received (date_start for Voice) in the CDR.
+            It filters on the time the API call was received by Nexmo and corresponds to the field `date_received` (`date_start` for Voice) in the report file. It is inclusive, i.e. the provided value is less than or equal to the value in the field `date_received` (`date_start` for Voice) in the CDR.
 
-              If you provide this, you must provide `date_end` and must not provide `message_id`
-            to seven days ago.
+            If you provide this, you must provide `date_end` and must not provide `id`.
           example: "2017-12-01T00:00:00+0000"
           in: query
         - name: date_end
@@ -99,9 +98,9 @@ paths:
 
             ISO-8601 extended time zone offset or ISO-8601 UTC zone offset formatted date (format `yyyy-mm-ddThh:mm:ss[.sss]±hh:mm` or `yyyy-mm-ddThh:mm:ss[.sss]Z`) for when report should end.
 
-            It is exclusive, i.e. the provided value is strictly greater than the value in the field date_received in the CDR.
+            It is exclusive, i.e. the provided value is strictly greater than the value in the field `date_received` in the CDR.
 
-              If you provide this, you must provide `date_start` and must not provide `message_id`
+            If you provide this, you must provide `date_start` and must not provide `id`.
           example: "2018-01-01T00:00:00+0000"
           in: query
         - name: include_message
@@ -267,14 +266,14 @@ paths:
             type: string
           example: SUCCESS, FAILED
         - name: date_from
-          description: ISO-8601 extended time zone offset or ISO-8601 UTC zone offset formatted date from which the list of reports will be queried. Format yyyy-mm-ddThh:mm:ss[.sss]±hh:mm or yyyy-mm-ddThh:mm:ss[.sss]Z
+          description: ISO-8601 extended time zone offset or ISO-8601 UTC zone offset formatted date from which the list of reports will be queried. Format `yyyy-mm-ddThh:mm:ss[.sss]±hh:mm` or `yyyy-mm-ddThh:mm:ss[.sss]Z`.
           in: query
           schema:
             type: string
             format: date
           example: "2019-06-28T00:00:00-00:00"
         - name: date_to
-          description: ISO-8601 extended time zone offset or ISO-8601 UTC zone offset formatted date until which the list of reports will be queried. Format yyyy-mm-ddThh:mm:ss[.sss]±hh:mm or yyyy-mm-ddThh:mm:ss[.sss]Z
+          description: ISO-8601 extended time zone offset or ISO-8601 UTC zone offset formatted date until which the list of reports will be queried. Format `yyyy-mm-ddThh:mm:ss[.sss]±hh:mm` or `yyyy-mm-ddThh:mm:ss[.sss]Z`.
           in: query
           schema:
             type: string
@@ -774,17 +773,17 @@ components:
       type: string
       format: date
       description: >
-        ISO-8601 extended time zone offset or ISO-8601 UTC zone offset formatted date (format yyyy-mm-ddThh:mm:ss[.sss]±hh:mm or yyyy-mm-ddThh:mm:ss[.sss]Z) for when reports 
-        should begin. It filters on the time the API call was received by Nexmo and corresponds to the field date_received (date_start for Voice) in the report file. It is
-        inclusive, i.e. the provided value is less than or equal to the value in the field date_received (date_start for Voice) in the CDR.<br>If unspecified, defaults 
+        ISO-8601 extended time zone offset or ISO-8601 UTC zone offset formatted date (format `yyyy-mm-ddThh:mm:ss[.sss]±hh:mm` or `yyyy-mm-ddThh:mm:ss[.sss]Z`) for when reports 
+        should begin. It filters on the time the API call was received by Nexmo and corresponds to the field `date_received` (`date_start` for Voice) in the report file. It is
+        inclusive, i.e. the provided value is less than or equal to the value in the field `date_received` (`date_start` for Voice) in the CDR.<br>If unspecified, defaults 
         to seven days ago.
       example: "2017-12-01T00:00:00+00:00"
     date_end:
       type: string
       format: date
       description: >
-        ISO-8601 extended time zone offset or ISO-8601 UTC zone offset formatted date (format yyyy-mm-ddThh:mm:ss[.sss]±hh:mm or yyyy-mm-ddThh:mm:ss[.sss]Z) for when report should end. 
-        It is exclusive, i.e. the provided value is strictly greater than the value in the field date_received in the CDR. <br>If unspecified, defaults to the current time.
+        ISO-8601 extended time zone offset or ISO-8601 UTC zone offset formatted date (format `yyyy-mm-ddThh:mm:ss[.sss]±hh:mm` or `yyyy-mm-ddThh:mm:ss[.sss]Z`) for when report should end. 
+        It is exclusive, i.e. the provided value is strictly greater than the value in the field `date_received` in the CDR. <br>If unspecified, defaults to the current time.
       example: "2018-01-01T00:00:00+00:00"
     client_ref:
       type: string


### PR DESCRIPTION
# Fixes

* The correct parameter name is `id` not `message_id`
* Fixed example value for `id`.
* Formatting fixes for date formats.
* Removed errant text “to seven days ago“

# Checklist

- [x] version number incremented (in the `info` section of the spec)
