### PR TITLE
Clarify event_url requirements in VAPI create a call action

### DIFF
--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -28,7 +28,6 @@ paths:
               required:
                 - to
                 - from
-                - event_url
               properties:
                 to:
                   type: array
@@ -74,7 +73,10 @@ paths:
                   - POST
                   - GET
                 event_url:
-                  description: The webhook endpoint where call progress events are
+                  description: |
+                    **Required** unless `event_url` provided at the application level, see [Create an Application](/api/application.v2#createApplication)
+
+                    The webhook endpoint where call progress events are
                     sent to. For more information about the values sent, see [Event webhook](/voice/voice-api/webhook-reference#event-webhook).
                   type: array
                   x-nexmo-developer-collection-description-shown: true

--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: 1.2.7
+  version: 1.2.8
   title: Voice API
   description: The Voice API lets you create outbound calls, control in-progress calls
     and get information about historical calls. More information about the Voice API
@@ -74,10 +74,12 @@ paths:
                   - GET
                 event_url:
                   description: |
-                    **Required** unless `event_url` provided at the application level, see [Create an Application](/api/application.v2#createApplication)
+                    **Required** unless `event_url` is configured at the application
+                    level, see [Create an Application](/api/application.v2#createApplication)
 
                     The webhook endpoint where call progress events are
-                    sent to. For more information about the values sent, see [Event webhook](/voice/voice-api/webhook-reference#event-webhook).
+                    sent to. For more information about the values sent, see
+                    [Event webhook](/voice/voice-api/webhook-reference#event-webhook).
                   type: array
                   x-nexmo-developer-collection-description-shown: true
                   example: '["https://example.com/event"]'


### PR DESCRIPTION
# Description

# Fixes

* Clarify that `event_url` parameter is only required for creating a call request when it is not previously set at the application level.

# Checklist

- [x] version number incremented (in the `info` section of the spec)
