### PR TITLE
OpenAPI Release workflow now supports multiple specs being edited in …

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -69,9 +69,4 @@ jobs:
               process.exit(1);
             }
 
-            if (versions.length > 1) {
-              console.log("Multiple specification versions changed in a single PR");
-              process.exit(1);
-            }
-
         if: steps.skip_check.outputs.result == 'execute'


### PR DESCRIPTION
Update GH Actions workflow as we now support more than one specification change at a time

# Checklist

- [ ] version number incremented (in the `info` section of the spec)
^ Not required