### PR TITLE
Mark as deprecated

### DIFF
--- a/definitions/developer/messages.yml
+++ b/definitions/developer/messages.yml
@@ -3,6 +3,15 @@ info:
   title: Message Search API
   version: 1.0.4
   description: >-
+
+    <div class="Vlt-callout Vlt-callout--critical">
+    <i></i>
+    <div class="Vlt-callout__content">
+      <h4>The Message Search API is deprecated</h4>
+      Please use the <a href="/reports/overview">Reports API</a> instead. See the <a href="/reports/guides/migrate-from-sms-message-search">Migrating from the SMS Message Search API guide</a> to get started.
+    </div>
+    </div>
+
     The Messages API lets you retrieve messages you have sent via the SMS API by
     ID, as well as retrieve details of messages that were rejected.
   contact:

--- a/definitions/developer/messages.yml
+++ b/definitions/developer/messages.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Message Search API
-  version: 1.0.4
+  version: 1.0.5
   description: >-
 
     <div class="Vlt-callout Vlt-callout--critical">


### PR DESCRIPTION
# Description

The SMS Message Search API is deprecated and we will direct people to a guide (under [PR 2933](https://github.com/Nexmo/nexmo-developer/pull/2933) that shows them how to use the Reports API instead.

**Please merge [PR 2933](https://github.com/Nexmo/nexmo-developer/pull/2933) first before merging the auto-created PR on NDP**

More info:

- [DEVX-2879](https://nexmoinc.atlassian.net/browse/DEVX-2879)
- [DEVX-2847](https://nexmoinc.atlassian.net/browse/DEVX-2847)

Example:

# New 

* Added deprecation warning and a link to a migration guide

# Checklist

- [X] version number incremented (in the `info` section of the spec)
