### PR TITLE
Update description of From and To in getCall(s) for Voice API

### DIFF
--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: 1.2.9
+  version: 1.2.10
   title: Voice API
   description:
     The Voice API lets you create outbound calls, control in-progress calls
@@ -692,35 +692,29 @@ components:
       example: CON-f972836a-550f-45fa-956c-12a2ab5b7d22
       description: The unique identifier for the conversation this call leg is part of.
     from:
-      type: array
+      type: object
       description: The endpoint you called from. Possible values are the same as `to`.
-      title: The number or address that has been called
-      items:
-        type: object
-        properties:
-          type:
-            type: string
-            title: The type of Endpoint that made the call
-            example: phone
-          number:
-            type: string
-            title: The number that made the call
-            example: "447700900001"
+      properties:
+        type:
+          type: string
+          title: The type of Endpoint that made the call
+          example: phone
+        number:
+          type: string
+          title: The number that made the call
+          example: '447700900001'
     to:
-      type: array
+      type: object
       description: The single or mixed collection of endpoint types you connected to
-      title: The number or address to call
-      items:
-        type: object
-        properties:
-          type:
-            type: string
-            title: The Type of Endpoint Called
-            example: phone
-          number:
-            type: string
-            title: The number of the endpoint called
-            example: "447700900000"
+      properties:
+        type:
+          type: string
+          title: The Type of Endpoint Called
+          example: phone
+        number:
+          type: string
+          title: The number of the endpoint called
+          example: '447700900000'
     status:
       type: string
       title: The State of the call

--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -845,7 +845,7 @@ components:
           format: uuid
           example: CON-171b3991-49b0-4dfa-badd-2bc6e68b57b4
         to:
-          $ref: "#/components/schemas/from"
+          $ref: "#/components/schemas/to"
         from:
           $ref: "#/components/schemas/from"
         uuid:

--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -523,8 +523,8 @@ components:
               properties:
                 href:
                   type: string
-                  title: Link to the object
-                  example: "/calls?page_size=10&record_index=20&order=asc"
+                  title: Link to the Call Object
+                  example: "/calls/63f61863-4a51-4f6b-86e1-46edebcf9356"
         uuid:
           $ref: "#/components/schemas/uuid"
         conversation_uuid:
@@ -585,42 +585,7 @@ components:
             calls:
               type: array
               items:
-                type: object
-                properties:
-                  _links:
-                    type: object
-                    properties:
-                      self:
-                        type: object
-                        properties:
-                          href:
-                            type: string
-                            title: The Link to the Call Object
-                            example: "/calls/63f61863-4a51-4f6b-86e1-46edebcf9356"
-                  uuid:
-                    $ref: "#/components/schemas/uuid"
-                  conversation_uuid:
-                    $ref: "#/components/schemas/conversation_uuid"
-                  to:
-                    $ref: "#/components/schemas/to"
-                  from:
-                    $ref: "#/components/schemas/from"
-                  status:
-                    $ref: "#/components/schemas/status"
-                  direction:
-                    $ref: "#/components/schemas/direction"
-                  rate:
-                    $ref: "#/components/schemas/rate"
-                  price:
-                    $ref: "#/components/schemas/price"
-                  duration:
-                    $ref: "#/components/schemas/duration"
-                  start_time:
-                    $ref: "#/components/schemas/start_time"
-                  end_time:
-                    $ref: "#/components/schemas/end_time"
-                  network:
-                    $ref: "#/components/schemas/network"
+                $ref: "#/components/schemas/GetCallResponse"
 
     CreateCallResponse:
       type: object
@@ -720,11 +685,6 @@ components:
       title: The State of the call
       example: started
       description: The status of the call. [See possible values](https://developer.nexmo.com/voice/voice-api/guides/call-flow#event-objects)
-
-    name_user:
-      type: string
-      example: my_user_name
-      description: Unique name for a user
 
     EndpointApp:
       type: object
@@ -830,52 +790,6 @@ components:
       maxLength: 50
       example: wss://example.com/socket
 
-    callEvent:
-      type: object
-      required:
-        - conversation_uuid
-        - to
-        - from
-        - uuid
-        - status
-      properties:
-        conversation_uuid:
-          description: The UUID of the Conversion that the event relates to
-          type: string
-          format: uuid
-          example: CON-171b3991-49b0-4dfa-badd-2bc6e68b57b4
-        to:
-          $ref: "#/components/schemas/to"
-        from:
-          $ref: "#/components/schemas/from"
-        uuid:
-          description: The UUID of the call leg that the event relates to
-          type: string
-          format: uuid
-          example: 63f61863-4a51-4f6b-86e1-46edebcf9356
-        timestamp:
-          type: string
-          format: date-time
-          example: 2018-01-12T15:01:55.315Z
-        status:
-          type: string
-          example: started
-          enum:
-            - started
-            - ringing
-            - answered
-            - machine
-            - completed
-            - timeout
-            - failed
-            - rejected
-            - cancelled
-            - busy
-        direction:
-          type: string
-          enum:
-            - inbound
-            - outbound
     voice_name:
       description: The voice & language to use
       type: string


### PR DESCRIPTION
# Description

The `GET /v1/calls` endpoint returns a different data structure (slightly!) than we describe in the spec. Spec says: array of objects with "from" and "number" properties. But I actually just get one of those objects, no array. This PR updates the spec to describe this.

# Fixes

* Improve the way we specify `from` and `to` in the "get calls" endpoint of Voice API

# Checklist

- [x] version number incremented (in the `info` section of the spec)
