### PR TITLE
Verify API only returns 101 from the search endpoint

### DIFF
--- a/definitions/verify.yml
+++ b/definitions/verify.yml
@@ -3,7 +3,7 @@ servers:
   - url: "https://api.nexmo.com/verify"
 info:
   title: Nexmo Verify API
-  version: 1.1.1
+  version: 1.1.2
   description: >-
     The Verify API helps you to implement 2FA (two-factor authentication) in your applications.
     This is useful for:
@@ -973,7 +973,6 @@ components:
             - "6"
             - "16"
             - "17"
-            - "101"
           description: |
             Code | Text | Description
             -- | -- | --
@@ -986,7 +985,6 @@ components:
             6 | The Nexmo platform was unable to process this message for the following reason: `$reason` | The request could not be routed.
             16 | The code inserted does not match the expected value |
             17 | The wrong code was provided too many times | You can run Verify check on a specific `request_id` up to three times unless a new verification code is generated. If you check a request more than three times, it is set to FAILED and you cannot check it again.
-            101 | No request found | There are no matching verify requests.
         error_text:
           type: string
           description: If the `status` is non-zero, this explains the error encountered.
@@ -1186,7 +1184,6 @@ components:
             - "8"
             - "9"
             - "19"
-            - "101"
           description: |
             Code | Text | Description
             -- | -- | --
@@ -1200,7 +1197,6 @@ components:
             8 | The api_key you supplied is for an account that has been barred from submitting messages. |
             9 | Partner quota exceeded | Your account does not have sufficient credit to process this request.
             19 | For `cancel`: Either you have not waited at least 30 secs after sending a Verify request before cancelling or Verify has made too many attempts to deliver the verification code for this request and you must now wait for the process to complete. For `trigger_next_event`: All attempts to deliver the verification code for this request have completed and there are no remaining events to advance to.
-            101 | No request found | There are no matching verify requests.
         error_text:
           type: string
           description: If the `status` is non-zero, this explains the error encountered.


### PR DESCRIPTION
# Fixes

* Update Verify status response codes - only `/search` returns the status 101 response


# Checklist

- [x] version number incremented (in the `info` section of the spec)
