### PR TITLE
Add x-hide-request flag to Messages OAS

### DIFF
--- a/definitions/dispatch.yml
+++ b/definitions/dispatch.yml
@@ -19,6 +19,7 @@ paths:
       summary: Create a workflow
       operationId: createWorkflow
       requestBody:
+        x-hide-request: true
         description: Please note that last message does not have failover attribute inside it. All other messages must contain a failover attribute.
         required: true
         content:

--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -19,6 +19,7 @@ paths:
       summary: Send a Message
       operationId: NewMessage
       requestBody:
+        x-hide-request: true
         description: Send a Message.
         required: true
         content:


### PR DESCRIPTION
# Description

Marks the request bodies for Messages & Dispatch as non-renderable in the new Nexmo OAS Renderer