### PR TITLE
Correct length_timer description

### DIFF
--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: 1.3.0
+  version: 1.3.1
   title: Voice API
   description:
     The Voice API lets you create outbound calls, control in-progress calls
@@ -542,7 +542,7 @@ components:
           example: continue
         length_timer:
           description: Set the number of seconds that elapse before Nexmo
-            hangs up after the call state changes to in_progress.
+            hangs up after the call state changes to answered.
           minimum: 1
           maximum: 7200
           default: 7200


### PR DESCRIPTION
# Description

Fixes:
* Correct `length_timer` description to match an actual VAPI call state, which is `answered`. Tested behavior in the API to confirm that this is actually so.

# Checklist

- [x] version number incremented (in the `info` section of the spec)
