### PR TITLE
Make visible each PUT request example from the VAPI spec

### DIFF
--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: 1.3.2
+  version: 1.3.3
   title: Voice API
   description:
     The Voice API lets you create outbound calls, control in-progress calls
@@ -159,6 +159,7 @@ paths:
                 - "$ref": "#/components/schemas/UpdateCallRequestUnmute"
                 - "$ref": "#/components/schemas/UpdateCallRequestEarmuff"
                 - "$ref": "#/components/schemas/UpdateCallRequestUnearmuff"
+      requests:
       responses:
         "204":
           description: No Content


### PR DESCRIPTION
# New

* Makes visible the schema for request example types already present in the spec

# Checklist

- [x] version number incremented (in the `info` section of the spec)
