### PR TITLE
Update spectral, the 5.4.0 version is failing but 5.5.0 is out now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
   - gem update --system 3.0.3
   - gem update bundler
   - nvm install
-  - npm install -g @stoplight/spectral@5.4.0
+  - npm install -g @stoplight/spectral@5.5.0
 install: bundle install --deployment --path vendor/bundle
 script:
   - bin/validate-specs.sh


### PR DESCRIPTION
# Description

A few days ago, the builds all started failing. I can replicate this locally and upgrading spectral helps.

# Fixes

* Builds failing with `lifecycle_1.createEventEmitter is not a function`

# Checklist

- [ ] version number incremented (in the `info` section of the spec)

^ version number not incremented because no specs were harmed in the creation of this pull request