### PR TITLE
Number insight  refresh

### DIFF
--- a/definitions/number-insight.yml
+++ b/definitions/number-insight.yml
@@ -4,7 +4,7 @@ servers:
   - url: "https://api.nexmo.com/ni"
 info:
   title: Number Insight API
-  version: 1.0.7
+  version: 1.0.8
   description: >-
     Nexmo's Number Insight API delivers real-time intelligence about the validity, reachability and roaming status of a phone number and tells you how to format the number correctly in your application. There are three levels of Number Insight API available: [Basic, Standard and Advanced](https://developer.nexmo.com/number-insight/overview#basic-standard-and-advanced-apis). The advanced API is available asynchronously as well as synchronously.
   contact:

--- a/definitions/number-insight.yml
+++ b/definitions/number-insight.yml
@@ -720,7 +720,7 @@ components:
               description: "If there is an internal lookup error, the `refund_price` will reflect the lookup price. If `cnam` is requested for a non-US number the `refund_price` will reflect the `cnam` price. If both of these conditions occur, `refund_price` is the sum of the lookup price and `cnam` price."
               example: "0.01500000"
             remaining_balance:
-              type: number
+              type: string
               description: "Your account balance in EUR after this request."
               example: "1.23456789"
             current_carrier:

--- a/definitions/number-insight.yml
+++ b/definitions/number-insight.yml
@@ -227,6 +227,10 @@ components:
             name: requestPrice
         status:
           $ref: "#/components/schemas/niStandardAdvancedStatus"
+        error_text:
+          type: string
+          description: "The status description of your request. Note: This field is equivalent to `status_message` field in the other endpoints"
+          example: "Success"
 
     niResponseXmlBasic:
       type: object


### PR DESCRIPTION
# Description

While working with the Number Insights API I found a couple of really minor things so I fixed them.

# Fixes

* Adds the missing `error_text` field to the async response of Number Insight API
* Corrects the `remaining_balance` data type to be a string everywhere on Number Insight API

# Checklist

- [x] version number incremented (in the `info` section of the spec)
