### PR TITLE
removing accidentally added sms MO & swapping id/number for viber inbound

### DIFF
--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -99,11 +99,7 @@ components:
           description: The datetime of when the event occurred.
           example: "2020-01-01T14:00:00.000Z"   
     inbound-message:
-      oneOf:
-        - title: SMS
-          x-tab-id: SMS
-          allOf:
-            - $ref: "#/components/schemas/SmsCommon"  
+      oneOf:        
         - title: WhatsApp
           x-tab-id: WhatsApp
           oneOf:                    

--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: 0.3.10
+  version: 0.3.11
   title: Messages API
   description: "The Messaging API is a new API that consolidates all messaging channels. It encapsulates a user (developer) from having to use multiple APIs to interact with our various channels such as SMS, MMS, Viber, Facebook Messenger, etc. The API normalises information across all channels to abstracted to, from and content. This API is currently in Beta."
   contact:

--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -153,13 +153,13 @@ components:
               x-tab-id: text
               allOf:
                 - $ref: "#/components/schemas/inbound-common"
-                - $ref: "#/components/schemas/channelOptionsViberCommon"
+                - $ref: "#/components/schemas/channelOptionsInboundViberCommon"
                 - $ref: "#/components/schemas/textMessageViberInbound"                     
             - title: Unsupported
               x-tab-id: unsupported
               allOf:
                 - $ref: "#/components/schemas/inbound-common"
-                - $ref: "#/components/schemas/channelOptionsViberCommon"
+                - $ref: "#/components/schemas/channelOptionsInboundViberCommon"
                 - $ref: "#/components/schemas/unsupportedMessage"
         - title: Facebook Messenger
           x-tab-id: Messenger
@@ -1262,6 +1262,45 @@ components:
             client_ref:
               $ref: "#/components/schemas/client_ref"
         - $ref: "#/components/schemas/SmsCommon"
+    channelOptionsInboundViberCommon:
+      required:
+        - to
+        - from
+      type: object
+      properties:
+        to:
+          required:
+            - type
+            - id
+          type: object
+          properties:
+            type:
+              type: string
+              description: The channel you are sending to
+              example: viber_service_msg
+              enum:
+                - viber_service_msg
+            id:
+              type: string
+              description: This is your Service Message ID given to you by Nexmo Account Manager. To find out more please visit [nexmo.com/products/messages](https://www.vonage.com/communications-apis/messages/).
+              example: '654321'
+        from:
+          required:
+            - type
+            - number
+          type: object
+          properties:
+            type:
+              type: string
+              description: The channel your message will be coming from.
+              example: viber_service_msg
+              enum:
+                - viber_service_msg
+            number:
+              type: string
+              example: '447700900000'
+              description: |
+                The Viber number of the message recipient in the [E.164](https://en.wikipedia.org/wiki/E.164) format. Don't use a leading + or 00 when entering a phone number, start with the country code, for example, 447700900000.            
     channelOptionsViberCommon:
       required:
         - to


### PR DESCRIPTION
# Description

* Accidentally added SMS MO to previous spec refresh - removing as it's not supported by the Messages API yet.
* Also needed to swap the id/number for viber inbound messages.
# Checklist

- [x] version number incremented (in the `info` section of the spec)
