### PR TITLE
Refreshing Applications API (and common errors)

### DIFF
--- a/definitions/application.v2.yml
+++ b/definitions/application.v2.yml
@@ -38,31 +38,7 @@ paths:
           content:
             application/json:
               schema:
-                properties:
-                  page_size:
-                    type: integer
-                    example: 10
-                    description: The number of applications per page
-                  page:
-                    type: integer
-                    example: 1
-                    description: The current page number (starts at 1)
-                  total_items:
-                    type: integer
-                    example: 6
-                    description: The total number of applications
-                  total_pages:
-                    type: integer
-                    example: 1
-                    description: The total number of pages returned
-                  _embedded:
-                    type: object
-                    description: A list of applications matching your existing filters
-                    properties:
-                      applications:
-                        type: array
-                        items:
-                          $ref: "#/components/schemas/ApplicationResponse"
+                $ref: "#/components/schemas/ApplicationResponseCollection"
         "400":
           description: Invalid Request
           content:
@@ -574,6 +550,33 @@ components:
                 $ref: "common/common_errors.yml#/components/fields/instance"
 
   schemas:
+    ApplicationResponseCollection:
+      properties:
+        page_size:
+          type: integer
+          example: 10
+          description: The number of applications per page
+        page:
+          type: integer
+          example: 1
+          description: The current page number (starts at 1)
+        total_items:
+          type: integer
+          example: 6
+          description: The total number of applications
+        total_pages:
+          type: integer
+          example: 1
+          description: The total number of pages returned
+        _embedded:
+          type: object
+          description: A list of applications matching your existing filters
+          properties:
+            applications:
+              type: array
+              items:
+                $ref: "#/components/schemas/ApplicationResponse"
+
     ApplicationResponse:
       properties:
         id:

--- a/definitions/application.v2.yml
+++ b/definitions/application.v2.yml
@@ -4,11 +4,11 @@ info:
   version: 2.0.5
   title: "Application API"
   description: |
-    Nexmo provides an Application API to allow management of your Nexmo Applications.
+    Vonage provides an Application API to allow management of your Vonage Applications.
 
     This API is backwards compatible with version 1. Applications created using version 1 of the API can also be managed using version 2 (this version) of the API.
   contact:
-    name: Nexmo
+    name: Vonage
     url: "https://developer.nexmo.com/"
     email: devrel@nexmo.com
 servers:
@@ -120,7 +120,7 @@ paths:
                           properties:
                             answer_url:
                               type: object
-                              description: "The URL that Nexmo make a request to when a call is placed/received. Must return an NCCO"
+                              description: "The URL that Vonage makes a request to when a call is placed/received. Must return an NCCO"
                               x-nexmo-developer-collection-description-shown: true
                               properties:
                                 address:
@@ -135,7 +135,7 @@ paths:
                             fallback_answer_url:
                               type: object
                               description: |
-                                If your `answer_url` is offline or returns a HTTP error code, Nexmo will make a request to a
+                                If your `answer_url` is offline or returns a HTTP error code, Vonage will make a request to a
                                 `fallback_answer_url` if it is set. This URL must return an NCCO.
                               x-nexmo-developer-collection-description-shown: true
                               properties:
@@ -150,7 +150,7 @@ paths:
                                     - POST
                             event_url:
                               type: object
-                              description: "Nexmo will send call events (e.g. `ringing`, `answered`) to this URL"
+                              description: "Vonage will send call events (e.g. `ringing`, `answered`) to this URL"
                               x-nexmo-developer-collection-description-shown: true
                               properties:
                                 address:
@@ -172,7 +172,7 @@ paths:
                           properties:
                             event_url:
                               type: object
-                              description: "Nexmo will send RTC events to this URL"
+                              description: "Vonage will send RTC events to this URL"
                               x-nexmo-developer-collection-description-shown: true
                               properties:
                                 address:
@@ -194,7 +194,7 @@ paths:
                           properties:
                             inbound_url:
                               type: object
-                              description: "Nexmo will forward inbound messages to this URL"
+                              description: "Vonage will forward inbound messages to this URL"
                               x-nexmo-developer-collection-description-shown: true
                               properties:
                                 address:
@@ -207,7 +207,7 @@ paths:
                                     - POST
                             status_url:
                               type: object
-                              description: "Nexmo will send message status updates (e.g. `delivered`, `seen`) to this URL"
+                              description: "Vonage will send message status updates (e.g. `delivered`, `seen`) to this URL"
                               x-nexmo-developer-collection-description-shown: true
                               properties:
                                 address:
@@ -345,7 +345,7 @@ paths:
                           properties:
                             answer_url:
                               type: object
-                              description: "The URL that Nexmo make a request to when a call is placed/received. Must return an NCCO"
+                              description: "The URL that Vonage make a request to when a call is placed/received. Must return an NCCO"
                               x-nexmo-developer-collection-description-shown: true
                               properties:
                                 address:
@@ -360,7 +360,7 @@ paths:
                             fallback_answer_url:
                               type: object
                               description: |
-                                If your `answer_url` is offline or returns a HTTP error code, Nexmo will make a request to a
+                                If your `answer_url` is offline or returns a HTTP error code, Vonage will make a request to a
                                 `fallback_answer_url` if it is set. This URL must return an NCCO
                               x-nexmo-developer-collection-description-shown: true
                               properties:
@@ -376,7 +376,7 @@ paths:
 
                             event_url:
                               type: object
-                              description: "Nexmo will send call events (e.g. `ringing`, `answered`) to this URL"
+                              description: "Vonage will send call events (e.g. `ringing`, `answered`) to this URL"
                               x-nexmo-developer-collection-description-shown: true
                               properties:
                                 address:
@@ -398,7 +398,7 @@ paths:
                           properties:
                             event_url:
                               type: object
-                              description: "Nexmo will send RTC events to this URL"
+                              description: "Vonage will send RTC events to this URL"
                               x-nexmo-developer-collection-description-shown: true
                               properties:
                                 address:
@@ -420,7 +420,7 @@ paths:
                           properties:
                             inbound_url:
                               type: object
-                              description: "Nexmo will forward inbound messages to this URL"
+                              description: "Vonage will forward inbound messages to this URL"
                               x-nexmo-developer-collection-description-shown: true
                               properties:
                                 address:
@@ -433,7 +433,7 @@ paths:
                                     - POST
                             status_url:
                               type: object
-                              description: "Nexmo will send message status updates (e.g. `delivered`, `seen`) to this URL"
+                              description: "Vonage will send message status updates (e.g. `delivered`, `seen`) to this URL"
                               x-nexmo-developer-collection-description-shown: true
                               properties:
                                 address:
@@ -604,7 +604,7 @@ components:
                         address:
                           type: string
                           example: https://example.com/webhooks/answer
-                          description: The URL that Nexmo requests when a call is placed/received. Must return an NCCO
+                          description: The URL that Vonage requests when a call is placed/received. Must return an NCCO
                         http_method:
                           type: string
                           example: POST
@@ -616,7 +616,7 @@ components:
                           type: string
                           example: https://fallback.example.com/webhooks/answer
                           description: |
-                            If your `answer_url` is offline or returns a HTTP error code, Nexmo will make a request to a
+                            If your `answer_url` is offline or returns a HTTP error code, Vonage will make a request to a
                             `fallback_answer_url` if it is set. This URL must return an NCCO.
                         http_method:
                           type: string
@@ -628,7 +628,7 @@ components:
                         address:
                           type: string
                           example: https://example.com/webhooks/event
-                          description: The URL that Nexmo sends events related to your call to
+                          description: The URL that Vonage sends events related to your call to
                         http_method:
                           type: string
                           example: POST
@@ -646,7 +646,7 @@ components:
                         address:
                           type: string
                           example: https://example.com/webhooks/inbound
-                          description: The URL that Nexmo forwards inbound messages to on your server
+                          description: The URL that Vonage forwards inbound messages to on your server
                         http_method:
                           type: string
                           example: POST
@@ -657,7 +657,7 @@ components:
                         address:
                           type: string
                           example: https://example.com/webhooks/status
-                          description: The URL that Nexmo sends events related to your messages to
+                          description: The URL that Vonage sends events related to your messages to
                         http_method:
                           type: string
                           example: POST

--- a/definitions/application.v2.yml
+++ b/definitions/application.v2.yml
@@ -1,7 +1,7 @@
 ---
 openapi: "3.0.0"
 info:
-  version: 2.0.5
+  version: 2.0.6
   title: "Application API"
   description: |
     Vonage provides an Application API to allow management of your Vonage Applications.

--- a/definitions/application.v2.yml
+++ b/definitions/application.v2.yml
@@ -66,7 +66,7 @@ paths:
                           type: string
                           example: must be between 1 and 100
                   instance:
-                    $ref: "common/common_errors.yml#/components/fields/instance"
+                    $ref: "common/common_errors.yml#/components/schemas/instance"
         "401":
           $ref: "common/common_errors.yml#/components/responses/BadCredentialsError"
         "405":
@@ -277,7 +277,7 @@ paths:
         in: path
         required: true
         description: The ID of the application
-        example: 78d335fa323d01149c3dd6f0d48968cf
+        example: 78d335fa-323d-0114-9c3d-d6f0d48968cf
         schema:
           type: string
     get:
@@ -547,7 +547,7 @@ components:
                       type: string
                       example: "must be one of: GET, POST"
               instance:
-                $ref: "common/common_errors.yml#/components/fields/instance"
+                $ref: "common/common_errors.yml#/components/schemas/instance"
 
   schemas:
     ApplicationResponseCollection:
@@ -581,7 +581,7 @@ components:
       properties:
         id:
           type: string
-          example: 78d335fa323d01149c3dd6f0d48968cf
+          example: 78d335fa-323d-0114-9c3d-d6f0d48968cf
           description: The application's ID
         name:
           type: string

--- a/definitions/common/common_errors.yml
+++ b/definitions/common/common_errors.yml
@@ -1,6 +1,6 @@
 ---
 components:
-  fields:
+  schemas:
     instance:
       type: string
       example: 797a8f199c45014ab7b08bfe9cc1c12c
@@ -21,7 +21,7 @@ components:
                 type: string
                 example: THIS IS A PLACEHOLDER FOR OTHER ERRORS
               instance:
-                $ref: "#/components/fields/instance"
+                $ref: "#/components/schemas/instance"
     BadCredentialsError:
       description: Credential is missing or invalid
       content:
@@ -38,7 +38,7 @@ components:
                 type: string
                 example: You did not provide correct credentials.
               instance:
-                $ref: "#/components/fields/instance"
+                $ref: "#/components/schemas/instance"
     NotFoundError:
       description: Resource Not Found
       content:
@@ -55,7 +55,7 @@ components:
                 type: string
                 example: ID 'ABC123' does not exist, or you do not have access
               instance:
-                $ref: "#/components/fields/instance"
+                $ref: "#/components/schemas/instance"
     InvalidRequestMethod:
       description: Invalid Request Method
       content:
@@ -72,7 +72,7 @@ components:
                 type: string
                 example: Request method 'TRACE' not supported
               instance:
-                $ref: "#/components/fields/instance"
+                $ref: "#/components/schemas/instance"
     InvalidAcceptHeader:
       description: Invalid Accept Header
       content:
@@ -89,7 +89,7 @@ components:
                 type: string
                 example: "Invalid Accept header provided. Must be one of the following: 'application/json'"
               instance:
-                $ref: "#/components/fields/instance"
+                $ref: "#/components/schemas/instance"
     UnsupportedContentTypeHeader:
       description: Unsupported Content Type Header
       content:
@@ -106,4 +106,4 @@ components:
                 type: string
                 example: "Unsupported Content-Type header provided. Must be one of the following: 'application/json'"
               instance:
-                $ref: "#/components/fields/instance"
+                $ref: "#/components/schemas/instance"


### PR DESCRIPTION
# Description

Applications uses content from another file but when the API definition is hydrated with that referenced content, the resulting output isn't valid OpenAPI, so this fixes that - plus a few other minor things that I found when integrating with Go.

# Fixes

* Improved examples and data types, renamed the common errors component.

# Checklist

- [x] version number incremented (in the `info` section of the spec)
