### PR TITLE
Reinstate Voice Name field, marked as deprecated

### DIFF
--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -323,6 +323,8 @@ components:
           $ref: "#/components/schemas/language"
         style:
           $ref: "#/components/schemas/style"
+        voice_name:
+          $ref: "#/components/schemas/voice_name"
         loop:
           type: integer
           description: The number of times to repeat the text the file, 0
@@ -972,6 +974,108 @@ components:
       type: integer
       default: 0
       
+    voice_name:
+      description: The voice & language to use
+      type: string
+      deprecated: true
+      default: Kimberly
+      enum:
+        - Aditi
+        - Agnieszka
+        - Alva
+        - Amy
+        - Astrid
+        - Bianca
+        - Brian
+        - Carla
+        - Carmen
+        - Carmit
+        - Catarina
+        - Celine
+        - Cem
+        - Chantal
+        - Chipmunk
+        - Conchita
+        - Cristiano
+        - Damayanti
+        - Dora
+        - Emma
+        - Empar
+        - Enrique
+        - Eric
+        - Ewa
+        - Felipe
+        - Filiz
+        - Geraint
+        - Giorgio
+        - Gwyneth
+        - Hans
+        - Henrik
+        - Ines
+        - Ioana
+        - Iveta
+        - Ivy
+        - Jacek
+        - Jan
+        - Jennifer
+        - Joana
+        - Joanna
+        - Joey
+        - Jordi
+        - Justin
+        - Kanya
+        - Karl
+        - Kendra
+        - Kimberly
+        - Laila
+        - Laura
+        - Lea
+        - Lekha
+        - Liv
+        - Lotte
+        - Lucia
+        - Luciana
+        - Mads
+        - Maged
+        - Maja
+        - Mariska
+        - Marlene
+        - Mathieu
+        - Matthew
+        - Maxim
+        - Mei-Jia
+        - Melina
+        - Mia
+        - Miguel
+        - Miren
+        - Mizuki
+        - Montserrat
+        - Naja
+        - Nicole
+        - Nikos
+        - Nora
+        - Oskar
+        - Penelope
+        - Raveena
+        - Ricardo
+        - Ruben
+        - Russell
+        - Salli
+        - Satu
+        - Seoyeon
+        - Sin-Ji
+        - Sora
+        - Takumi
+        - Tarik
+        - Tatyana
+        - Tessa
+        - Tian-Tian
+        - Vicki
+        - Vitoria
+        - Yelda
+        - Zeina
+        - Zhiyu
+        - Zuzana
 
 tags:
   - name: Calls

--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: 1.3.4
+  version: 1.3.5
   title: Voice API
   description:
     The Voice API lets you create outbound calls, control in-progress calls
@@ -975,7 +975,7 @@ components:
       default: 0
       
     voice_name:
-      description: The voice & language to use
+      description: <strong>DEPRECATED</strong> The voice & language to use
       type: string
       deprecated: true
       default: Kimberly


### PR DESCRIPTION
# Description

When the recommended TTS fields changed from `voice_name` to `language` and `style`, we completely removed the `voice_name` from the API description but it's still supported in the API itself. A more accurate way to describe the API would be to include the field but clearly mark it as deprecated.

(see also: an open issue to have our docs mark this more clearly. Other platforms should do it though https://github.com/Nexmo/nexmo-oas-renderer/issues/87)

# Fixes

* Keep the old voice name field docs for reference


# Checklist

- [x] version number incremented (in the `info` section of the spec)
