### PR TITLE
Update conversions.yml

### DIFF
--- a/definitions/conversion.yml
+++ b/definitions/conversion.yml
@@ -64,12 +64,57 @@ paths:
           description: OK
         "401":
           description: Wrong credentials
+          $ref: "#/components/responses/BadCredentialsError"
         "402":
           description: Conversion has not been enabled for your account
+          content:
+            application/json:
+              schema:
+                properties:
+                  type:
+                    type: string
+                    description: URL for further information
+                    example: https://developer.nexmo.com/api-errors#forbidden
+                  title:
+                    type: string
+                    description: Description of the error
+                    example: Conversion has not been enabled for your account
         "420":
           description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                properties:
+                  type:
+                    type: string
+                    description: URL for further information
+                    example: https://developer.nexmo.com/api-errors#3
+                  title:
+                    type: string
+                    description: Description of the error
+                    example: Invalid parameters. The value of one or more parameters is invalid.
+                  resolution:
+                    type: string
+                    description: Methods to solve
+                    example: Check your parameters and try again.
         "423":
           description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                properties:
+                  type:
+                    type: string
+                    description: URL for further information
+                    example: https://developer.nexmo.com/api-errors#3
+                  title:
+                    type: string
+                    description: Description of the error
+                    example: Invalid parameters. The value of one or more parameters is invalid.
+                  resolution:
+                    type: string
+                    description: Methods to solve
+                    example: Check your parameters and try again.
   /voice:
     post:
       operationId: voiceConversion
@@ -90,12 +135,57 @@ paths:
           description: OK
         "401":
           description: Wrong credentials
+          $ref: "#/components/responses/BadCredentialsError"
         "402":
           description: Conversion has not been enabled for your account
+          content:
+            application/json:
+              schema:
+                properties:
+                  type:
+                    type: string
+                    description: URL for further information
+                    example: https://developer.nexmo.com/api-errors#forbidden
+                  title:
+                    type: string
+                    description: Description of the error
+                    example: Conversion has not been enabled for your account
         "420":
           description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                properties:
+                  type:
+                    type: string
+                    description: URL for further information
+                    example: https://developer.nexmo.com/api-errors#3
+                  title:
+                    type: string
+                    description: Description of the error
+                    example: Invalid parameters. The value of one or more parameters is invalid.
+                  resolution:
+                    type: string
+                    description: Methods to solve
+                    example: Check your parameters and try again.
         "423":
           description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                properties:
+                  type:
+                    type: string
+                    description: URL for further information
+                    example: https://developer.nexmo.com/api-errors#3
+                  title:
+                    type: string
+                    description: Description of the error
+                    example: Invalid parameters. The value of one or more parameters is invalid.
+                  resolution:
+                    type: string
+                    description: Methods to solve
+                    example: Check your parameters and try again.
 components:
   parameters:
     message-id:


### PR DESCRIPTION
All the other API Reference had "Example Response" but Conversion API Reference showed only error numbers. Hence, checked the API & added proper Example Responses accordingly.

# Description

Although Conversion API is based on POST operations, the example responses section in the documentation showed only numbers without proper example responses. Check it here: https://developer.nexmo.com/api/conversion

![output](https://user-images.githubusercontent.com/58947271/95782324-4b988000-0ced-11eb-9ea9-e32d961836f4.JPG)


Example Responses:
200, 401, 402, 420, 423

# New 

* Added the application/json in conversions.yml  containing valid Example Responses of 401, 402, 420, 423 types.
