### PR TITLE
Conversation API beta/beta2 endpoints transition to v0.1/v0.2

### DIFF
--- a/definitions/conversation.v2.yml
+++ b/definitions/conversation.v2.yml
@@ -1,8 +1,8 @@
 openapi: 3.0.0
 servers:
-  - url: "https://api.nexmo.com/beta2"
+  - url: "https://api.nexmo.com/v0.2"
 info:
-  version: 0.2.1
+  version: 1.0.0
   title: Nexmo Conversation API
   description: "The Nexmo Conversation API enables you to build conversation features where communication can take place across multiple mediums including IP Messaging, PSTN Voice, SMS and WebRTC Audio and Video. The context of the conversations is maintained though each communication event taking place within a conversation, no matter the medium."
   contact:
@@ -38,6 +38,10 @@ paths:
                     type: integer
                     example: 10
                     description: The number of results returned on this page.
+                  cursor:
+                    type: string
+                    example: 88b395c167da4d94e929705cbd63b82973771e7d390d274a58e301386d5762600a3ffd799bfb3fc5190c5a0d124cdd0fc72fe6e450506b18e4e2edf9fe84c7a0
+                    description: Current cursor
                   _embedded:
                     type: object
                     x-nexmo-developer-collection-description-shown: true
@@ -58,25 +62,25 @@ paths:
                         properties:
                           href:
                             type: string
-                            example: "https://api.nexmo.com/beta2/conversations?order=desc&page_size=10"
+                            example: "https://api.nexmo.com/v0.2/conversations?order=desc&page_size=10"
                       self:
                         type: object
                         properties:
                           href:
                             type: string
-                            example: "https://api.nexmo.com/beta2/conversations?order=desc&page_size=10&cursor=88b395c167da4d94e929705cbd63b82973771e7d390d274a58e301386d5762600a3ffd799bfb3fc5190c5a0d124cdd0fc72fe6e450506b18e4e2edf9fe84c7a0"
+                            example: "https://api.nexmo.com/v0.2/conversations?order=desc&page_size=10&cursor=88b395c167da4d94e929705cbd63b82973771e7d390d274a58e301386d5762600a3ffd799bfb3fc5190c5a0d124cdd0fc72fe6e450506b18e4e2edf9fe84c7a0"
                       next:
                         type: object
                         properties:
                           href:
                             type: string
-                            example: "https://api.nexmo.com/beta2/conversations?order=desc&page_size=10&cursor=88b395c167da4d94e929705cbd63b829a650e69a39197bfd4c949f4243f60dc4babb696afa404d2f44e7775e32b967f2a1a0bb8fb259c0999ba5a4e501eaab55"
+                            example: "https://api.nexmo.com/v0.2/conversations?order=desc&page_size=10&cursor=88b395c167da4d94e929705cbd63b829a650e69a39197bfd4c949f4243f60dc4babb696afa404d2f44e7775e32b967f2a1a0bb8fb259c0999ba5a4e501eaab55"
                       prev:
                         type: object
                         properties:
                           href:
                             type: string
-                            example: "https://api.nexmo.com/beta2/conversations?order=desc&page_size=10&cursor=069626a3de11d2ec900dff5042197bd75f1ce41dafc3f2b2481eb9151086e59aae9dba3e3a8858dc355232d499c310fbfbec43923ff657c0de8d49ffed9f7edb"
+                            example: "https://api.nexmo.com/v0.2/conversations?order=desc&page_size=10&cursor=069626a3de11d2ec900dff5042197bd75f1ce41dafc3f2b2481eb9151086e59aae9dba3e3a8858dc355232d499c310fbfbec43923ff657c0de8d49ffed9f7edb"
 
   "/users":
     get:
@@ -97,6 +101,10 @@ paths:
                     type: integer
                     example: 10
                     description: The number of results returned on this page
+                  cursor:
+                    type: string
+                    example: 88b395c167da4d94e929705cbd63b82973771e7d390d274a58e301386d5762600a3ffd799bfb3fc5190c5a0d124cdd0fc72fe6e450506b18e4e2edf9fe84c7a0
+                    description: Current cursor
                   _embedded:
                     type: object
                     x-nexmo-developer-collection-description-shown: true
@@ -117,25 +125,25 @@ paths:
                         properties:
                           href:
                             type: string
-                            example: "https://api.nexmo.com/beta2/users?order=desc&page_size=10"
+                            example: "https://api.nexmo.com/v0.2/users?order=desc&page_size=10"
                       self:
                         type: object
                         properties:
                           href:
                             type: string
-                            example: "https://api.nexmo.com/beta2/users?order=desc&page_size=10&cursor=88b395c167da4d94e929705cbd63b82973771e7d390d274a58e301386d5762600a3ffd799bfb3fc5190c5a0d124cdd0fc72fe6e450506b18e4e2edf9fe84c7a0"
+                            example: "https://api.nexmo.com/v0.2/users?order=desc&page_size=10&cursor=88b395c167da4d94e929705cbd63b82973771e7d390d274a58e301386d5762600a3ffd799bfb3fc5190c5a0d124cdd0fc72fe6e450506b18e4e2edf9fe84c7a0"
                       next:
                         type: object
                         properties:
                           href:
                             type: string
-                            example: "https://api.nexmo.com/beta2/users?order=desc&page_size=10&cursor=88b395c167da4d94e929705cbd63b829a650e69a39197bfd4c949f4243f60dc4babb696afa404d2f44e7775e32b967f2a1a0bb8fb259c0999ba5a4e501eaab55"
+                            example: "https://api.nexmo.com/v0.2/users?order=desc&page_size=10&cursor=88b395c167da4d94e929705cbd63b829a650e69a39197bfd4c949f4243f60dc4babb696afa404d2f44e7775e32b967f2a1a0bb8fb259c0999ba5a4e501eaab55"
                       prev:
                         type: object
                         properties:
                           href:
                             type: string
-                            example: "https://api.nexmo.com/beta2/users?order=desc&page_size=10&cursor=069626a3de11d2ec900dff5042197bd75f1ce41dafc3f2b2481eb9151086e59aae9dba3e3a8858dc355232d499c310fbfbec43923ff657c0de8d49ffed9f7edb"
+                            example: "https://api.nexmo.com/v0.2/users?order=desc&page_size=10&cursor=069626a3de11d2ec900dff5042197bd75f1ce41dafc3f2b2481eb9151086e59aae9dba3e3a8858dc355232d499c310fbfbec43923ff657c0de8d49ffed9f7edb"
 
   "/conversations/{conversation_id}/members":
     get:
@@ -179,25 +187,25 @@ paths:
                         properties:
                           href:
                             type: string
-                            example: "https://api.nexmo.com/beta2/members?order=desc&page_size=10"
+                            example: "https://api.nexmo.com/v0.2/members?order=desc&page_size=10"
                       self:
                         type: object
                         properties:
                           href:
                             type: string
-                            example: "https://api.nexmo.com/beta2/members?order=desc&page_size=10&cursor=88b395c167da4d94e929705cbd63b82973771e7d390d274a58e301386d5762600a3ffd799bfb3fc5190c5a0d124cdd0fc72fe6e450506b18e4e2edf9fe84c7a0"
+                            example: "https://api.nexmo.com/v0.2/members?order=desc&page_size=10&cursor=88b395c167da4d94e929705cbd63b82973771e7d390d274a58e301386d5762600a3ffd799bfb3fc5190c5a0d124cdd0fc72fe6e450506b18e4e2edf9fe84c7a0"
                       next:
                         type: object
                         properties:
                           href:
                             type: string
-                            example: "https://api.nexmo.com/beta2/members?order=desc&page_size=10&cursor=88b395c167da4d94e929705cbd63b829a650e69a39197bfd4c949f4243f60dc4babb696afa404d2f44e7775e32b967f2a1a0bb8fb259c0999ba5a4e501eaab55"
+                            example: "https://api.nexmo.com/v0.2/members?order=desc&page_size=10&cursor=88b395c167da4d94e929705cbd63b829a650e69a39197bfd4c949f4243f60dc4babb696afa404d2f44e7775e32b967f2a1a0bb8fb259c0999ba5a4e501eaab55"
                       prev:
                         type: object
                         properties:
                           href:
                             type: string
-                            example: "https://api.nexmo.com/beta2/members?order=desc&page_size=10&cursor=069626a3de11d2ec900dff5042197bd75f1ce41dafc3f2b2481eb9151086e59aae9dba3e3a8858dc355232d499c310fbfbec43923ff657c0de8d49ffed9f7edb"
+                            example: "https://api.nexmo.com/v0.2/members?order=desc&page_size=10&cursor=069626a3de11d2ec900dff5042197bd75f1ce41dafc3f2b2481eb9151086e59aae9dba3e3a8858dc355232d499c310fbfbec43923ff657c0de8d49ffed9f7edb"
 
   "/conversations/{conversation_id}/events":
     get:
@@ -244,25 +252,25 @@ paths:
                         properties:
                           href:
                             type: string
-                            example: "https://api.nexmo.com/beta2/conversations/CON-92a44c64-7e4e-485f-a0c4-1f2adfc44625/events?page_size=10"
+                            example: "https://api.nexmo.com/v0.2/conversations/CON-92a44c64-7e4e-485f-a0c4-1f2adfc44625/events?page_size=10"
                       self:
                         type: object
                         properties:
                           href:
                             type: string
-                            example: "https://api.nexmo.com/beta2/conversations/CON-92a44c64-7e4e-485f-a0c4-1f2adfc44625/events?page_size=10&cursor=a30e3b7a3dcda1434f64bbb1a5fa489b"
+                            example: "https://api.nexmo.com/v0.2/conversations/CON-92a44c64-7e4e-485f-a0c4-1f2adfc44625/events?page_size=10&cursor=a30e3b7a3dcda1434f64bbb1a5fa489b"
                       next:
                         type: object
                         properties:
                           href:
                             type: string
-                            example: "https://api.nexmo.com/beta2/conversations/CON-92a44c64-7e4e-485f-a0c4-1f2adfc44625/events?page_size=10&cursor=4db03d9254d1cdaecc7b1fc15b6bf1a81f3d3151191d784f1327893f8dc96416"
+                            example: "https://api.nexmo.com/v0.2/conversations/CON-92a44c64-7e4e-485f-a0c4-1f2adfc44625/events?page_size=10&cursor=4db03d9254d1cdaecc7b1fc15b6bf1a81f3d3151191d784f1327893f8dc96416"
                       prev:
                         type: object
                         properties:
                           href:
                             type: string
-                            example: "https://api.nexmo.com/beta2/conversations/CON-92a44c64-7e4e-485f-a0c4-1f2adfc44625/events?page_size=10&cursor=84963f79fd25785be9706bd38bfd30c264f71964fa4edc8d8b4dd5f30bbd9f7c"
+                            example: "https://api.nexmo.com/v0.2/conversations/CON-92a44c64-7e4e-485f-a0c4-1f2adfc44625/events?page_size=10&cursor=84963f79fd25785be9706bd38bfd30c264f71964fa4edc8d8b4dd5f30bbd9f7c"
 
 components:
   parameters:
@@ -473,7 +481,7 @@ components:
               properties:
                 href:
                   type: string
-                  example: "https://api.nexmo.com/beta2/conversations/CON-92a44c64-7e4e-485f-a0c4-1f2adfc44625/events/9"
+                  example: "https://api.nexmo.com/v0.2/conversations/CON-92a44c64-7e4e-485f-a0c4-1f2adfc44625/events/9"
 
     member_list:
       type: object
@@ -509,7 +517,7 @@ components:
               properties:
                 href:
                   type: string
-                  example: https://api.nexmo.com/beta2/conversations/CON-92a44c64-7e4e-485f-a0c4-1f2adfc44625/members/MEM-e784d5d1-dff2-424a-9de7-bc34f1901177
+                  example: https://api.nexmo.com/v0.2/conversations/CON-92a44c64-7e4e-485f-a0c4-1f2adfc44625/members/MEM-e784d5d1-dff2-424a-9de7-bc34f1901177
 
     member:
       allOf:
@@ -604,7 +612,7 @@ components:
               properties:
                 href:
                   type: string
-                  example: "https://api.nexmo.com/beta2/conversations/CON-c4724477-72ac-438e-9fc0-1d3e2ff8728c"
+                  example: "https://api.nexmo.com/v0.2/conversations/CON-c4724477-72ac-438e-9fc0-1d3e2ff8728c"
 
     conversation_id:
       type: string
@@ -649,7 +657,7 @@ components:
           properties:
             href:
               type: string
-              example: https://api.nexmo.com/beta2/users/USR-e46d9542-752a-4786-8f12-25a2e623a793
+              example: https://api.nexmo.com/v0.2/users/USR-e46d9542-752a-4786-8f12-25a2e623a793
 
 tags:
   - name: conversation

--- a/definitions/conversation.yml
+++ b/definitions/conversation.yml
@@ -28,6 +28,7 @@ paths:
         List all conversations associated with your application. 
         This endpoint required an admin JWT. To find all conversations for
         the currently logged in user, see [GET /users/:id/conversations](#getuserConversations)
+      deprecated: true
       parameters:
         - $ref: "#/components/parameters/date_start"
         - $ref: "#/components/parameters/date_end"
@@ -210,7 +211,7 @@ paths:
         <p><strong>This API endpoint is deprecated. Please use <a href="/api/conversation.v2#get-events">/v0.2/events</a></strong><br />This endpoint will return a maximum of 100 items.</p>
         </div>
         </div>
-
+      deprecated: true
       tags:
         - event
       summary: List events
@@ -297,6 +298,7 @@ paths:
         <p><strong>This API endpoint is deprecated. Please use <a href="/api/conversation.v2#get-members">/v0.2/members</a></strong><br />This endpoint will return a maximum of 100 items.</p>
         </div>
         </div>
+      deprecated: true
       tags:
         - member
       summary: List members
@@ -437,6 +439,7 @@ paths:
         <strong>This API endpoint is deprecated. Please use <a href="/api/conversation.v2#get-users">/v0.2/users</a><br />This endpoint will return a maximum of 100 items.</strong>
         </div>
         </div>
+      deprecated: true
       tags:
         - user
       summary: List users

--- a/definitions/conversation.yml
+++ b/definitions/conversation.yml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers:
   - url: "https://api.nexmo.com/v0.1"
 info:
-  version: 1.7.9
+  version: 2.0.0
   title: Nexmo Conversation API
   description: "The Nexmo Conversation API enables you to build conversation features where communication can take place across multiple mediums including IP Messaging, PSTN Voice, SMS and WebRTC Audio and Video. The context of the conversations is maintained though each communication event taking place within a conversation, no matter the medium."
   contact:

--- a/definitions/conversation.yml
+++ b/definitions/conversation.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 servers:
-  - url: "https://api.nexmo.com/beta"
+  - url: "https://api.nexmo.com/v0.1"
 info:
   version: 1.7.9
   title: Nexmo Conversation API
@@ -21,7 +21,7 @@ paths:
         <div class="Vlt-callout Vlt-callout--warning">
         <i></i>
         <div class="Vlt-callout__content">
-        <p><strong>This API endpoint is deprecated. Please use <a href="/api/conversation.v2#get-conversations">/beta2/conversations</a></strong>.<br />This endpoint will return a maximum of 100 items.</p>
+        <p><strong>This API endpoint is deprecated. Please use <a href="/api/conversation.v2#get-conversations">/v0.2/conversations</a></strong>.<br />This endpoint will return a maximum of 100 items.</p>
         </div>
         </div>
 
@@ -65,8 +65,14 @@ paths:
                               $ref: "#/components/schemas/conversation_id"
                             name:
                               $ref: "#/components/schemas/name_conversation"
-                            href:
-                              $ref: "#/components/schemas/href_conversation"
+                            _links:
+                              type: object
+                              properties:
+                                self:
+                                  type: object
+                                  properties:
+                                    href:
+                                      $ref: "#/components/schemas/href_conversation"
                           required:
                             - uuid
                             - name
@@ -201,7 +207,7 @@ paths:
         <div class="Vlt-callout Vlt-callout--warning">
         <i></i>
         <div class="Vlt-callout__content">
-        <p><strong>This API endpoint is deprecated. Please use <a href="/api/conversation.v2#get-events">/beta2/events</a></strong><br />This endpoint will return a maximum of 100 items.</p>
+        <p><strong>This API endpoint is deprecated. Please use <a href="/api/conversation.v2#get-events">/v0.2/events</a></strong><br />This endpoint will return a maximum of 100 items.</p>
         </div>
         </div>
 
@@ -288,7 +294,7 @@ paths:
         <div class="Vlt-callout Vlt-callout--warning">
         <i></i>
         <div class="Vlt-callout__content">
-        <p><strong>This API endpoint is deprecated. Please use <a href="/api/conversation.v2#get-members">/beta2/members</a></strong><br />This endpoint will return a maximum of 100 items.</p>
+        <p><strong>This API endpoint is deprecated. Please use <a href="/api/conversation.v2#get-members">/v0.2/members</a></strong><br />This endpoint will return a maximum of 100 items.</p>
         </div>
         </div>
       tags:
@@ -428,7 +434,7 @@ paths:
         <div class="Vlt-callout Vlt-callout--warning">
         <i></i>
         <div class="Vlt-callout__content">
-        <strong>This API endpoint is deprecated. Please use <a href="/api/conversation.v2#get-users">/beta2/users</a><br />This endpoint will return a maximum of 100 items.</strong>
+        <strong>This API endpoint is deprecated. Please use <a href="/api/conversation.v2#get-users">/v0.2/users</a><br />This endpoint will return a maximum of 100 items.</strong>
         </div>
         </div>
       tags:
@@ -464,7 +470,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  user_id:
+                  id:
                     $ref: "#/components/schemas/user_id"
                   href:
                     $ref: "#/components/schemas/href_user"
@@ -502,7 +508,7 @@ paths:
                     $ref: "#/components/schemas/name_user"
                   href:
                     type: string
-                    example: "https://api.nexmo.com/beta/users/USR-63f61863-4a51-4f6b-86e1-46edebio0391"
+                    example: "https://api.nexmo.com/v0.1/users/USR-63f61863-4a51-4f6b-86e1-46edebio0391"
     put:
       operationId: updateUser
       tags:
@@ -662,7 +668,7 @@ paths:
                   record_index: 0
                   _links:
                     self:
-                      href: "https://api.nexmo.com/beta/legs"
+                      href: "https://api.nexmo.com/v0.1/legs"
                   _embedded:
                     legs:
                       - uuid: 2a71f8a1-b6f1-42b3-9eef-c69729e17513
@@ -680,7 +686,7 @@ paths:
                           state: terminated
                         _links:
                           self:
-                            href: "https://api.nexmo.com/beta/legs/2a71f8a1-b6f1-42b3-9eef-c69729e17513"
+                            href: "https://api.nexmo.com/v0.1/legs/2a71f8a1-b6f1-42b3-9eef-c69729e17513"
   "/legs/{leg_id}":
     parameters:
       - $ref: "#/components/parameters/leg_id"
@@ -789,37 +795,37 @@ components:
     href:
       type: string
       format: url
-      example: "https://api.nexmo.com/beta/conversations/CON-63f61863-4a51-4f6b-86e1-46edebio0391"
+      example: "https://api.nexmo.com/v0.1/conversations/CON-63f61863-4a51-4f6b-86e1-46edebio0391"
       description: A link towards a resources included in Conversation API
     href_conversation:
       type: string
       format: url
-      example: "https://api.nexmo.com/beta/conversations/CON-63f61863-4a51-4f6b-86e1-46edebio0391"
+      example: "https://api.nexmo.com/v0.1/conversations/CON-63f61863-4a51-4f6b-86e1-46edebio0391"
       description: A link towards a conversation included in Conversation API
     href_conversations_list:
       type: string
       format: url
-      example: "https://api.nexmo.com/beta/conversations?page_size=2&record_index=10&"
+      example: "https://api.nexmo.com/v0.1/conversations?page_size=2&record_index=10&"
       description: A link towards a conversations list included in Conversation API
     href_member:
       type: string
       format: url
-      example: "https://api.nexmo.com/beta/conversations/CON-63f61863-4a51-4f6b-86e1-46edebio0391/members/MEM-63f61863-4a51-4f6b-86e1-46edebio0391"
+      example: "https://api.nexmo.com/v0.1/conversations/CON-63f61863-4a51-4f6b-86e1-46edebio0391/members/MEM-63f61863-4a51-4f6b-86e1-46edebio0391"
       description: A link towards a member included in Conversation API
     href_user:
       type: string
       format: url
-      example: "https://api.nexmo.com/beta/users/USR-63f61863-4a51-4f6b-86e1-46edebio0391"
+      example: "https://api.nexmo.com/v0.1/users/USR-63f61863-4a51-4f6b-86e1-46edebio0391"
       description: A link towards a user included in Conversation API
     href_event:
       type: string
       format: url
-      example: "https://api.nexmo.com/beta/conversations/CON-63f61863-4a51-4f6b-86e1-46edebio0391/events/1"
+      example: "https://api.nexmo.com/v0.1/conversations/CON-63f61863-4a51-4f6b-86e1-46edebio0391/events/1"
       description: A link towards a conversation event included in Conversation API
     href_rtc:
       type: string
       format: url
-      example: "https://api.nexmo.com/beta/conversations/CON-63f61863-4a51-4f6b-86e1-46edebio0391/rtc/7777777777777"
+      example: "https://api.nexmo.com/v0.1/conversations/CON-63f61863-4a51-4f6b-86e1-46edebio0391/rtc/7777777777777"
       description: A link towards a rtc (leg) included in Conversation API
     event_id:
       type: string


### PR DESCRIPTION
# Changes 

* Transitioned the Conversation API endpoints from `beta` and `beta2` paths to `v0.1` and `v0.2` respectively.

# Checklist

- [x] version number incremented (in the `info` section of the spec)
