### PR TITLE
Verify API: error response for new accounts

### DIFF
--- a/definitions/verify.yml
+++ b/definitions/verify.yml
@@ -3,7 +3,7 @@ servers:
   - url: "https://api.nexmo.com/verify"
 info:
   title: Verify API
-  version: 1.1.5
+  version: 1.1.6
   description: >-
     The Verify API helps you to implement 2FA (two-factor authentication) in your applications.
     This is useful for:
@@ -135,10 +135,10 @@ paths:
                     error_text: The destination number is not in a supported network
 
                 not-permitted:
-                  summary: Non-Whitelisted Destination
+                  summary: Non-Permitted Destination
                   value:
                     status: "29"
-                    error_text: Your Vonage account is still in demo mode. While in demo mode you must add target numbers to your whitelisted destination list. Add funds to your account to remove this limitation.
+                    error_text: Your Vonage account is still in demo mode. While in demo mode you must add target numbers to the approved list for your account. Add funds to your account to remove this limitation.
 
               schema:
                 oneOf:
@@ -769,7 +769,7 @@ components:
             10 | Concurrent verifications to the same number are not allowed |
             15 | The destination number is not in a supported network | The request has been rejected. Find out more about this error in the [Knowledge Base](https://help.nexmo.com/hc/en-us/articles/360018406532-Verify-On-demand-Service-to-High-Risk-Countries)
             20 | This account does not support the parameter: pin_code. | Only certain accounts have the ability to set the `pin_code`. Please contact your account manager for more information.
-            29 | Non-Whitelisted Destination | Your Vonage account is still in demo mode. While in demo mode you must add target numbers to your whitelisted destination list. Add funds to your account to remove this limitation.
+            29 | Non-Permitted Destination | Your Vonage account is still in demo mode. While in demo mode you must add target numbers to the approved list for your account. Add funds to your account to remove this limitation.
 
         error_text:
           type: string

--- a/definitions/verify.yml
+++ b/definitions/verify.yml
@@ -134,6 +134,12 @@ paths:
                     status: "15"
                     error_text: The destination number is not in a supported network
 
+                not-permitted:
+                  summary: Non-Whitelisted Destination
+                  value:
+                    status: "29"
+                    error_text: Your Vonage account is still in demo mode. While in demo mode you must add target numbers to your whitelisted destination list. Top-up your account to remove this limitation.
+
               schema:
                 oneOf:
                   - $ref: "#/components/schemas/requestResponse"
@@ -746,6 +752,7 @@ components:
             - "10"
             - "15"
             - "20"
+            - "29"
           description: |
             Code | Text | Description
             -- | -- | --
@@ -762,6 +769,9 @@ components:
             10 | Concurrent verifications to the same number are not allowed |
             15 | The destination number is not in a supported network | The request has been rejected. Find out more about this error in the [Knowledge Base](https://help.nexmo.com/hc/en-us/articles/360018406532-Verify-On-demand-Service-to-High-Risk-Countries)
             20 | This account does not support the parameter: pin_code. | Only certain accounts have the ability to set the `pin_code`. Please contact your account manager for more information.
+            29 | Non-Whitelisted Destination | Your Vonage account is still in demo mode. While in demo mode you must add target numbers to your whitelisted destination list. Top-up your account to remove this limitation.
+
+
         error_text:
           type: string
           description: "If `status` is non-zero, this explains the error encountered."

--- a/definitions/verify.yml
+++ b/definitions/verify.yml
@@ -138,7 +138,7 @@ paths:
                   summary: Non-Whitelisted Destination
                   value:
                     status: "29"
-                    error_text: Your Vonage account is still in demo mode. While in demo mode you must add target numbers to your whitelisted destination list. Top-up your account to remove this limitation.
+                    error_text: Your Vonage account is still in demo mode. While in demo mode you must add target numbers to your whitelisted destination list. Add funds to your account to remove this limitation.
 
               schema:
                 oneOf:
@@ -769,8 +769,7 @@ components:
             10 | Concurrent verifications to the same number are not allowed |
             15 | The destination number is not in a supported network | The request has been rejected. Find out more about this error in the [Knowledge Base](https://help.nexmo.com/hc/en-us/articles/360018406532-Verify-On-demand-Service-to-High-Risk-Countries)
             20 | This account does not support the parameter: pin_code. | Only certain accounts have the ability to set the `pin_code`. Please contact your account manager for more information.
-            29 | Non-Whitelisted Destination | Your Vonage account is still in demo mode. While in demo mode you must add target numbers to your whitelisted destination list. Top-up your account to remove this limitation.
-
+            29 | Non-Whitelisted Destination | Your Vonage account is still in demo mode. While in demo mode you must add target numbers to your whitelisted destination list. Add funds to your account to remove this limitation.
 
         error_text:
           type: string


### PR DESCRIPTION
# Description

For new accounts (that haven't topped up yet), users can only use their own number for Verify testing. If they try to access another number, they need a message telling them what went wrong. Uses Code 29 to align with SMS API error codes.

# Fixes

* Error message when new users try to access non-permitted destinations with Verify API 

# Checklist

- [x] version number incremented (in the `info` section of the spec)
