### PR TITLE
Move Verify API request bodies to named schemas, add deprecated flags

### DIFF
--- a/definitions/verify.yml
+++ b/definitions/verify.yml
@@ -3,7 +3,7 @@ servers:
   - url: "https://api.nexmo.com/verify"
 info:
   title: Verify API
-  version: 1.1.4
+  version: 1.1.5
   description: >-
     The Verify API helps you to implement 2FA (two-factor authentication) in your applications.
     This is useful for:
@@ -54,146 +54,7 @@ paths:
         content:
           application/x-www-form-urlencoded:
             schema:
-              type: object
-              required:
-                - api_key
-                - api_secret
-                - number
-                - brand
-              properties:
-                api_key:
-                  $ref: "#/components/schemas/api_key"
-                api_secret:
-                  $ref: "#/components/schemas/api_secret"
-                number:
-                  type: string
-                  description: >-
-                    The mobile or landline phone number to verify. Unless you are
-                    setting `country` explicitly, this number must be in
-                    [E.164](https://en.wikipedia.org/wiki/E.164) format.
-                  example: "447700900000"
-                country:
-                  description: >-
-                    If you do not provide `number` in international format or you are not
-                    sure if `number` is correctly formatted, specify the two-character country
-                    code in `country`. Verify will then format the number for you.
-                  type: string
-                  example: GB
-                brand:
-                  description: >-
-                    An 18-character alphanumeric string you can use to personalize the verification
-                    request SMS body, to help users identify your company or application name.
-                    For example: "Your `Acme Inc` PIN is ..."
-                  type: string
-                  maxLength: 18
-                  example: Acme Inc
-                sender_id:
-                  description: >-
-                    An 11-character alphanumeric string that represents the [identity of the sender](https://developer.nexmo.com/messaging/sms/guides/custom-sender-id)
-                    of the verification request. Depending on the destination of the phone number you are sending the verification SMS to,
-                    restrictions might apply.
-                  type: string
-                  maxLength: 11
-                  default: VERIFY
-                  example: ACME
-                code_length:
-                  description: The length of the verification code.
-                  type: integer
-                  enum:
-                    - 4
-                    - 6
-                  default: 4
-                  example: 6
-                lg:
-                  description: >-
-                    By default, the SMS or text-to-speech (TTS) message is generated in
-                    the locale that matches the `number`. For example, the text message
-                    or TTS message for a `33*` number is sent in French. Use this
-                    parameter to explicitly control the language used for the Verify
-                    request. A list of languages is available: <https://developer.nexmo.com/verify/guides/verify-languages>
-                  example: en-us
-                  type: string
-                  default: en-us
-                  enum:
-                    - ar-xa
-                    - cs-cz
-                    - cy-cy
-                    - cy-gb
-                    - da-dk
-                    - de-de
-                    - el-gr
-                    - en-au
-                    - en-gb
-                    - en-in
-                    - en-us
-                    - es-es
-                    - es-mx
-                    - es-us
-                    - fi-fi
-                    - fil-ph
-                    - fr-ca
-                    - fr-fr
-                    - hi-in
-                    - hu-hu
-                    - id-id
-                    - is-is
-                    - it-it
-                    - ja-jp
-                    - ko-kr
-                    - nb-no
-                    - nl-nl
-                    - pl-pl
-                    - pt-br
-                    - pt-pt
-                    - ro-ro
-                    - ru-ru
-                    - sv-se
-                    - th-th
-                    - tr-tr
-                    - vi-vn
-                    - yue-cn
-                    - zh-cn
-                    - zh-tw
-                pin_expiry:
-                  description: >-
-                    How long the generated verification code is valid for, in seconds.
-                    When you specify both `pin_expiry` and `next_event_wait` then
-                    `pin_expiry` must be an integer multiple of `next_event_wait`
-                    otherwise `pin_expiry` is defaulted to equal next_event_wait. See
-                    [changing the event
-                    timings](https://developer.nexmo.com/verify/guides/changing-default-timings).
-                  type: integer
-                  minimum: 60
-                  maximum: 3600
-                  default: 300
-                  example: 240
-                next_event_wait:
-                  description: >-
-                    Specifies the wait time in seconds between attempts to deliver the
-                    verification code.
-                  type: integer
-                  minimum: 60
-                  maximum: 900
-                  default: 300
-                  example: 120
-                workflow_id:
-                  description: >-
-                    Selects the predefined sequence of SMS and TTS (Text To Speech)
-                    actions to use in order to convey the PIN to your user. For example,
-                    an id of 1 identifies the workflow SMS - TTS - TTS. For a list of
-                    all workflows and their associated ids, please visit the [developer
-                    portal](https://developer.nexmo.com/verify/guides/workflows-and-events).
-                  type: integer
-                  default: 1
-                  enum:
-                    - 1
-                    - 2
-                    - 3
-                    - 4
-                    - 5
-                    - 6
-                    - 7
-                  example: 4
+              $ref: "#/components/schemas/verifyRequest"
       responses:
         "200":
           description: OK
@@ -305,35 +166,7 @@ paths:
         content:
           application/x-www-form-urlencoded:
             schema:
-              type: object
-              required:
-                - api_key
-                - api_secret
-                - request_id
-                - code
-              properties:
-                api_key:
-                  $ref: "#/components/schemas/api_key"
-                api_secret:
-                  $ref: "#/components/schemas/api_secret"
-                request_id:
-                  description: >-
-                    The Verify request to check. This is the
-                    `request_id` you received in the response to the Verify request.
-                  type: string
-                  maxLength: 32
-                  example: abcdef0123456789abcdef0123456789
-                code:
-                  description: The verification code entered by your user.
-                  type: string
-                  minLength: 4
-                  maxLength: 6
-                  example: "1234"
-                ip_address:
-                  description: >-
-                    (This field is no longer used)
-                  type: string
-                  example: 123.0.0.255
+              $ref: "#/components/schemas/checkRequest"
       responses:
         "200":
           description: OK
@@ -448,6 +281,7 @@ paths:
             maxItems: 10
           style: form
           explode: true
+
       responses:
         "200":
           description: OK
@@ -557,34 +391,7 @@ paths:
         content:
           application/x-www-form-urlencoded:
             schema:
-              type: object
-              required:
-                - api_key
-                - api_secret
-                - request_id
-                - cmd
-              properties:
-                api_key:
-                  $ref: "#/components/schemas/api_key"
-                api_secret:
-                  $ref: "#/components/schemas/api_secret"
-                request_id:
-                  description: "The `request_id` you received in the response to the Verify request."
-                  type: string
-                  example: abcdef0123456789abcdef0123456789
-                cmd:
-                  description: >-
-                    The possible commands are `cancel` to request cancellation of
-                    the verification process, or `trigger_next_event` to advance 
-                    to the next verification event (if any).
-                    Cancellation is only possible 30 seconds after the start of the
-                    verification request and before the second event (either TTS or SMS)
-                    has taken place.
-                  type: string
-                  enum:
-                    - cancel
-                    - trigger_next_event
-                  example: cancel
+              $ref: "#/components/schemas/controlRequest"
 
       responses:
         "200":
@@ -685,126 +492,7 @@ paths:
         content:
           application/x-www-form-urlencoded:
             schema:
-              type: object
-              required:
-                - api_key
-                - api_secret
-                - number
-                - payee
-                - amount
-              properties:
-                api_key:
-                  $ref: "#/components/schemas/api_key"
-                api_secret:
-                  $ref: "#/components/schemas/api_secret"
-                number:
-                  type: string
-                  description: >-
-                    The mobile or landline phone number to verify. Unless you are
-                    setting `country` explicitly, this number must be in
-                    [E.164](https://en.wikipedia.org/wiki/E.164) format.
-                  example: "447700900000"
-                country:
-                  description: >-
-                    If you do not provide `number` in international format or you are not
-                    sure if `number` is correctly formatted, specify the two-character country
-                    code in `country`. Verify will then format the number for you.
-                  type: string
-                  example: GB
-                payee:
-                  description: >-
-                    An alphanumeric string to indicate to the user the name of the recipient
-                    that they are confirming a payment to.
-                  type: string
-                  maxLength: 18
-                  example: Acme Inc
-                amount:
-                  description: >-
-                    The decimal amount of the payment to be confirmed, in Euros
-                  type: number
-                  format: float
-                  example: "48.00"
-                code_length:
-                  description: The length of the verification code.
-                  type: integer
-                  enum:
-                    - 4
-                    - 6
-                  default: 4
-                  example: 6
-                lg:
-                  description: >-
-                    By default, the SMS or text-to-speech (TTS) message is generated in
-                    the locale that matches the `number`. For example, the text message
-                    or TTS message for a `33*` number is sent in French. Use this
-                    parameter to explicitly control the language used.
-
-                    *Note: Voice calls in English for `bg-bg`, `ee-et`, `ga-ie`, `lv-lv`, `lt-lt`, `mt-mt`, `sk-sk`, `sk-si`
-                  example: es-es
-                  type: string
-                  default: en-gb
-                  enum:
-                    - en-gb
-                    - bg-bg
-                    - cs-cz
-                    - da-dk
-                    - de-de
-                    - ee-et
-                    - el-gr
-                    - es-es
-                    - fi-fi
-                    - fr-fr
-                    - ga-ie
-                    - hu-hu
-                    - it-it
-                    - lv-lv
-                    - lt-lt
-                    - mt-mt
-                    - nl-nl
-                    - pl-pl
-                    - sk-sk
-                    - sl-si
-                    - sv-se
-                pin_expiry:
-                  description: >-
-                    How long the generated verification code is valid for, in seconds.
-                    When you specify both `pin_expiry` and `next_event_wait` then
-                    `pin_expiry` must be an integer multiple of `next_event_wait`
-                    otherwise `pin_expiry` is defaulted to equal next_event_wait. See
-                    [changing the event
-                    timings](https://developer.nexmo.com/verify/guides/changing-default-timings).
-                  type: integer
-                  minimum: 60
-                  maximum: 3600
-                  default: 300
-                  example: 240
-                next_event_wait:
-                  description: >-
-                    Specifies the wait time in seconds between attempts to deliver the
-                    verification code.
-                  type: integer
-                  minimum: 60
-                  maximum: 900
-                  default: 300
-                  example: 120
-                workflow_id:
-                  description: >-
-                    Selects the predefined sequence of SMS and TTS (Text To Speech)
-                    actions to use in order to convey the PIN to your user. For example,
-                    an id of 1 identifies the workflow SMS - TTS - TTS. For a list of
-                    all workflows and their associated ids, please visit the [developer
-                    portal](https://developer.nexmo.com/verify/guides/workflows-and-events).
-                  type: integer
-                  default: 1
-                  enum:
-                    - 1
-                    - 2
-                    - 3
-                    - 4
-                    - 5
-                    - 6
-                    - 7
-                  example: 4
+              $ref: "#/components/schemas/psd2Request"
 
       responses:
         "200":
@@ -868,6 +556,149 @@ components:
         overlap with message/call events. When this field is present, the total
         cost of the verification is the sum of this field and the `price` field.
       example: "0.03330000"
+
+    verifyRequest:
+      type: object
+      required:
+        - api_key
+        - api_secret
+        - number
+        - brand
+      properties:
+        api_key:
+          $ref: "#/components/schemas/api_key"
+        api_secret:
+          $ref: "#/components/schemas/api_secret"
+        number:
+          type: string
+          description: >-
+            The mobile or landline phone number to verify. Unless you are
+            setting `country` explicitly, this number must be in
+            [E.164](https://en.wikipedia.org/wiki/E.164) format.
+          example: "447700900000"
+        country:
+          description: >-
+            If you do not provide `number` in international format or you are not
+            sure if `number` is correctly formatted, specify the two-character country
+            code in `country`. Verify will then format the number for you.
+          type: string
+          example: GB
+        brand:
+          description: >-
+            An 18-character alphanumeric string you can use to personalize the verification
+            request SMS body, to help users identify your company or application name.
+            For example: "Your `Acme Inc` PIN is ..."
+          type: string
+          maxLength: 18
+          example: Acme Inc
+        sender_id:
+          description: >-
+            An 11-character alphanumeric string that represents the [identity of the sender](https://developer.nexmo.com/messaging/sms/guides/custom-sender-id)
+            of the verification request. Depending on the destination of the phone number you are sending the verification SMS to,
+            restrictions might apply.
+          type: string
+          maxLength: 11
+          default: VERIFY
+          example: ACME
+        code_length:
+          description: The length of the verification code.
+          type: integer
+          enum:
+            - 4
+            - 6
+          default: 4
+          example: 6
+        lg:
+          description: >-
+            By default, the SMS or text-to-speech (TTS) message is generated in
+            the locale that matches the `number`. For example, the text message
+            or TTS message for a `33*` number is sent in French. Use this
+            parameter to explicitly control the language used for the Verify
+            request. A list of languages is available: <https://developer.nexmo.com/verify/guides/verify-languages>
+          example: en-us
+          type: string
+          default: en-us
+          enum:
+            - ar-xa
+            - cs-cz
+            - cy-cy
+            - cy-gb
+            - da-dk
+            - de-de
+            - el-gr
+            - en-au
+            - en-gb
+            - en-in
+            - en-us
+            - es-es
+            - es-mx
+            - es-us
+            - fi-fi
+            - fil-ph
+            - fr-ca
+            - fr-fr
+            - hi-in
+            - hu-hu
+            - id-id
+            - is-is
+            - it-it
+            - ja-jp
+            - ko-kr
+            - nb-no
+            - nl-nl
+            - pl-pl
+            - pt-br
+            - pt-pt
+            - ro-ro
+            - ru-ru
+            - sv-se
+            - th-th
+            - tr-tr
+            - vi-vn
+            - yue-cn
+            - zh-cn
+            - zh-tw
+        pin_expiry:
+          description: >-
+            How long the generated verification code is valid for, in seconds.
+            When you specify both `pin_expiry` and `next_event_wait` then
+            `pin_expiry` must be an integer multiple of `next_event_wait`
+            otherwise `pin_expiry` is defaulted to equal next_event_wait. See
+            [changing the event
+            timings](https://developer.nexmo.com/verify/guides/changing-default-timings).
+          type: integer
+          minimum: 60
+          maximum: 3600
+          default: 300
+          example: 240
+        next_event_wait:
+          description: >-
+            Specifies the wait time in seconds between attempts to deliver the
+            verification code.
+          type: integer
+          minimum: 60
+          maximum: 900
+          default: 300
+          example: 120
+        workflow_id:
+          description: >-
+            Selects the predefined sequence of SMS and TTS (Text To Speech)
+            actions to use in order to convey the PIN to your user. For example,
+            an id of 1 identifies the workflow SMS - TTS - TTS. For a list of
+            all workflows and their associated ids, please visit the [developer
+            portal](https://developer.nexmo.com/verify/guides/workflows-and-events).
+          type: integer
+          default: 1
+          enum:
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
+            - 6
+            - 7
+          example: 4
+
     requestResponse:
       type: object
       description: Success
@@ -885,6 +716,7 @@ components:
           type: string
           description: "Indicates the outcome of the request; zero is success"
           example: "0"
+
     requestErrorResponse:
       type: object
       description: Error
@@ -934,6 +766,39 @@ components:
           type: string
           description: "If `status` is non-zero, this explains the error encountered."
           example: "Your request is incomplete and missing the mandatory parameter `number`"
+
+    checkRequest:
+      type: object
+      required:
+        - api_key
+        - api_secret
+        - request_id
+        - code
+      properties:
+        api_key:
+          $ref: "#/components/schemas/api_key"
+        api_secret:
+          $ref: "#/components/schemas/api_secret"
+        request_id:
+          description: >-
+            The Verify request to check. This is the
+            `request_id` you received in the response to the Verify request.
+          type: string
+          maxLength: 32
+          example: abcdef0123456789abcdef0123456789
+        code:
+          description: The verification code entered by your user.
+          type: string
+          minLength: 4
+          maxLength: 6
+          example: "1234"
+        ip_address:
+          description: >-
+            (This field is no longer used)
+          type: string
+          deprecated: true
+          example: 123.0.0.255
+
     checkResponse:
       type: object
       description: Success
@@ -966,6 +831,7 @@ components:
           $ref: "#/components/schemas/estimated_price_messages_sent"
       xml:
         name: verify_response
+
     checkErrorResponse:
       type: object
       description: Error
@@ -1007,6 +873,7 @@ components:
           example: The code inserted does not match the expected value
       xml:
         name: verify_response
+
     searchResponse:
       xml:
         name: verify_request
@@ -1106,6 +973,7 @@ components:
               ip_address:
                 type: string
                 description: The IP address, if available (this field is no longer used).
+                deprecated: true
                 example: 123.0.0.255
         events:
           type: array
@@ -1126,6 +994,7 @@ components:
                 type: string
         estimated_price_messages_sent:
           $ref: "#/components/schemas/estimated_price_messages_sent"
+
     searchErrorResponse:
       xml:
         name: verify_request
@@ -1160,6 +1029,37 @@ components:
           type: string
           description: If `status` is not `SUCCESS`, this message explains the issue encountered.
           example: No response found
+
+    controlRequest:
+      type: object
+      required:
+        - api_key
+        - api_secret
+        - request_id
+        - cmd
+      properties:
+        api_key:
+          $ref: "#/components/schemas/api_key"
+        api_secret:
+          $ref: "#/components/schemas/api_secret"
+        request_id:
+          description: "The `request_id` you received in the response to the Verify request."
+          type: string
+          example: abcdef0123456789abcdef0123456789
+        cmd:
+          description: >-
+            The possible commands are `cancel` to request cancellation of
+            the verification process, or `trigger_next_event` to advance 
+            to the next verification event (if any).
+            Cancellation is only possible 30 seconds after the start of the
+            verification request and before the second event (either TTS or SMS)
+            has taken place.
+          type: string
+          enum:
+            - cancel
+            - trigger_next_event
+          example: cancel
+
     controlResponse:
       type: object
       description: Success
@@ -1180,6 +1080,7 @@ components:
             - "cancel"
             - "trigger_next_event"
           example: "cancel"
+
     controlErrorResponse:
       type: object
       description: Error
@@ -1217,3 +1118,126 @@ components:
           type: string
           description: If the `status` is non-zero, this explains the error encountered.
           example: "The requestId 'abcdef0123456789abcdef' does not exist or its no longer active."
+
+    psd2Request:
+      type: object
+      required:
+        - api_key
+        - api_secret
+        - number
+        - payee
+        - amount
+      properties:
+        api_key:
+          $ref: "#/components/schemas/api_key"
+        api_secret:
+          $ref: "#/components/schemas/api_secret"
+        number:
+          type: string
+          description: >-
+            The mobile or landline phone number to verify. Unless you are
+            setting `country` explicitly, this number must be in
+            [E.164](https://en.wikipedia.org/wiki/E.164) format.
+          example: "447700900000"
+        country:
+          description: >-
+            If you do not provide `number` in international format or you are not
+            sure if `number` is correctly formatted, specify the two-character country
+            code in `country`. Verify will then format the number for you.
+          type: string
+          example: GB
+        payee:
+          description: >-
+            An alphanumeric string to indicate to the user the name of the recipient
+            that they are confirming a payment to.
+          type: string
+          maxLength: 18
+          example: Acme Inc
+        amount:
+          description: >-
+            The decimal amount of the payment to be confirmed, in Euros
+          type: number
+          format: float
+          example: "48.00"
+        code_length:
+          description: The length of the verification code.
+          type: integer
+          enum:
+            - 4
+            - 6
+          default: 4
+          example: 6
+        lg:
+          description: >-
+            By default, the SMS or text-to-speech (TTS) message is generated in
+            the locale that matches the `number`. For example, the text message
+            or TTS message for a `33*` number is sent in French. Use this
+            parameter to explicitly control the language used.
+
+            *Note: Voice calls in English for `bg-bg`, `ee-et`, `ga-ie`, `lv-lv`, `lt-lt`, `mt-mt`, `sk-sk`, `sk-si`
+          example: es-es
+          type: string
+          default: en-gb
+          enum:
+            - en-gb
+            - bg-bg
+            - cs-cz
+            - da-dk
+            - de-de
+            - ee-et
+            - el-gr
+            - es-es
+            - fi-fi
+            - fr-fr
+            - ga-ie
+            - hu-hu
+            - it-it
+            - lv-lv
+            - lt-lt
+            - mt-mt
+            - nl-nl
+            - pl-pl
+            - sk-sk
+            - sl-si
+            - sv-se
+        pin_expiry:
+          description: >-
+            How long the generated verification code is valid for, in seconds.
+            When you specify both `pin_expiry` and `next_event_wait` then
+            `pin_expiry` must be an integer multiple of `next_event_wait`
+            otherwise `pin_expiry` is defaulted to equal next_event_wait. See
+            [changing the event
+            timings](https://developer.nexmo.com/verify/guides/changing-default-timings).
+          type: integer
+          minimum: 60
+          maximum: 3600
+          default: 300
+          example: 240
+        next_event_wait:
+          description: >-
+            Specifies the wait time in seconds between attempts to deliver the
+            verification code.
+          type: integer
+          minimum: 60
+          maximum: 900
+          default: 300
+          example: 120
+        workflow_id:
+          description: >-
+            Selects the predefined sequence of SMS and TTS (Text To Speech)
+            actions to use in order to convey the PIN to your user. For example,
+            an id of 1 identifies the workflow SMS - TTS - TTS. For a list of
+            all workflows and their associated ids, please visit the [developer
+            portal](https://developer.nexmo.com/verify/guides/workflows-and-events).
+          type: integer
+          default: 1
+          enum:
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
+            - 6
+            - 7
+          example: 4
+


### PR DESCRIPTION
# Description

Structure change since moving to `POST` requests had left nameless objects in the API definition and this trips up some codegen tooling. The only other change is to add "deprecated" to the `ip_address` fields that we no longer use.

# Fixes

* Improved structure and object naming

# Checklist

- [x] version number incremented (in the `info` section of the spec)
