### PR TITLE
WIP - Nexmo to Vonage branding changes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2018 Nexmo Ltd.
+Copyright (c) 2020 Vonage
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://developer.nexmo.com/assets/images/Vonage_Nexmo.svg" height="48px" alt="Nexmo is now known as Vonage" />
 
-Provides [OpenAPI Specification (v3)](https://github.com/OAI/OpenAPI-Specification) definitions for Nexmo APIs.
+Provides [OpenAPI Specification (v3)](https://github.com/OAI/OpenAPI-Specification) definitions for Vonage APIs.
 
 ## Human-readable specifications
 
@@ -28,8 +28,8 @@ These definitions provide a single point of truth that can be used end-to-end:
 ## Tools
 
 - [Stoplight Studio](https://stoplight.io/studio/) - powerful spec editor with validation and local mock server
-- [Nexmo OAS Renderer](https://github.com/Nexmo/nexmo-oas-renderer) - Nexmo's tool for rendering OpenAPI specs to HTML.
-- [Nexmo Developer](https://github.com/Nexmo/nexmo-developer) - Nexmo Developer uses these specs and the renderer for the API reference pages.
+- [Vonage API OAS Renderer](https://github.com/Nexmo/nexmo-oas-renderer) - the Vonage tool for rendering OpenAPI specs to HTML.
+- [Vonage API Developer](https://github.com/Nexmo/nexmo-developer) - Vonage API Developer Portal uses these specs and the renderer for the API reference pages.
 
 ### Check your API spec for validity and style
 

--- a/definitions/account.yml
+++ b/definitions/account.yml
@@ -1,9 +1,9 @@
 openapi: "3.0.2"
 info:
-  title: "Nexmo Account API"
+  title: "Vonage Account API"
   version: "1.0.1"
   description: >-
-    Enables users to manage their Nexmo Account by programmable means. More information is available here: <https://developer.nexmo.com/account/overview>.
+    Enables users to manage their Vonage API Account by programmable means. More information is available here: <https://developer.nexmo.com/account/overview>.
   contact:
     name: Nexmo.com
     url: "https://developer.nexmo.com"
@@ -16,7 +16,7 @@ paths:
     get:
       operationId: getAccountBalance
       summary: Get Account Balance
-      description: Retrieve the current balance of your Nexmo account
+      description: Retrieve the current balance of your Vonage API account
       parameters:
         - $ref: "#/components/parameters/api_key_for_auth"
         - $ref: "#/components/parameters/api_secret_for_auth"
@@ -120,7 +120,7 @@ paths:
           * Callback URL for incoming SMS messages
           * Callback URL for delivery receipts
 
-        Note that the URLs you provide must be valid and active. Nexmo will check that they
+        Note that the URLs you provide must be valid and active. Vonage will check that they
         return a 200 OK response before the setting is saved.
       parameters:
         - $ref: "#/components/parameters/api_key_for_auth"
@@ -136,8 +136,8 @@ paths:
               properties:
                 moCallBackUrl:
                   description: >-
-                    The URL where Nexmo will send a webhook when an SMS is received
-                    to a Nexmo number that does not have SMS handling configured.
+                    The URL where Vonage will send a webhook when an SMS is received
+                    to a Vonage number that does not have SMS handling configured.
 
                     Send an empty string to unset this value.
                   type: string
@@ -145,7 +145,7 @@ paths:
                   example: https://example.com/webhooks/inbound-sms
                 drCallBackUrl:
                   description: >-
-                    The URL where Nexmo will send a webhook when an delivery
+                    The URL where Vonage will send a webhook when an delivery
                     receipt is received without a specific callback URL configured.
 
                     Send an empty string to unset this value.
@@ -422,7 +422,7 @@ tags:
     description: Manage the settings on your account
   - name: Secret Management
     description: >-
-      Many of Nexmo's APIs are accessed using an API key and secret. It is recommended that you change or "rotate" your secrets from time to time for security purposes. This section provides the API interface for achieving this.
+      Many of the Vonage APIs are accessed using an API key and secret. It is recommended that you change or "rotate" your secrets from time to time for security purposes. This section provides the API interface for achieving this.
 
       Note: to work on secrets for your secondary accounts, you may authenticate with your primary credentials and supply the secondary API keys as URL parameters to these API endpoints.
 
@@ -432,14 +432,14 @@ components:
       type: http
       scheme: basic
       description: >-
-        Provide an `Authorization` header, with a value of "Basic" followed by the result of base64-encoding your Nexmo API key and secret separated by a colon. You can find your API key and secret on the [dashboard](https://dashboard.nexmo.com) and more information is available [on the developer portal](https://developer.nexmo.com/concepts/guides/authentication#header-based-api-key-and-secret-authentication).
+        Provide an `Authorization` header, with a value of "Basic" followed by the result of base64-encoding your Vonage API key and secret separated by a colon. You can find your API key and secret on the [dashboard](https://dashboard.nexmo.com) and more information is available [on the developer portal](https://developer.nexmo.com/concepts/guides/authentication#header-based-api-key-and-secret-authentication).
 
         If your API key were aaa012 and your API secret were abc123456789 then your HTTP header would be: `Authorization: Basic YWFhMDEyOmFiYzEyMzQ1Njc4OQ==`
 
   parameters:
     api_key_for_auth:
       name: api_key
-      description: Your Nexmo API key. You can find this in the [dashboard](https://dashboard.nexmo.com)
+      description: Your Vonage API key. You can find this in the [dashboard](https://dashboard.nexmo.com)
       in: query
       required: true
       schema:
@@ -447,7 +447,7 @@ components:
         example: abcd1234
     api_secret_for_auth:
       name: api_secret
-      description: Your Nexmo API secret. You can find this in the [dashboard](https://dashboard.nexmo.com)
+      description: Your Vonage API secret. You can find this in the [dashboard](https://dashboard.nexmo.com)
       in: query
       required: true
       schema:

--- a/definitions/application.yml
+++ b/definitions/application.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  title: Nexmo Application API
+  title: Vonage Application API
   version: 1.0.2
   description: >-
     <div class="Vlt-callout Vlt-callout--critical">
@@ -11,8 +11,8 @@ info:
     </div>
     </div>
 
-    A Nexmo application contains the security and configuration information you
-    need to connect to Nexmo endpoints and easily use our products.
+    A Vonage application contains the security and configuration information you
+    need to connect to Vonage endpoints and easily use our products.
   contact:
     name: Nexmo.com
     email: devrel@nexmo.com
@@ -91,7 +91,7 @@ paths:
                   example: My Application
                 type:
                   description: >-
-                    The Nexmo product or products that you access with this
+                    The Vonage API product or products that you access with this
                     application. Currently `voice` and `messages` application types are supported.
                   type: string
                   example: voice
@@ -102,7 +102,7 @@ paths:
                   description: >-
                     The URL where your webhook delivers the Nexmo Call Control
                     Object that governs this call. As soon as your user answers
-                    a call Nexmo makes a request to `answer_url`. Required for inbound calls only.
+                    a call Vonage makes a request to `answer_url`. Required for inbound calls only.
                   type: string
                   example: "https://example.com/webhooks/answer"
                 answer_method:
@@ -113,7 +113,7 @@ paths:
                   example: GET
                 event_url:
                   description: >-
-                    Nexmo sends event information asynchronously to this URL
+                    Vonage sends event information asynchronously to this URL
                     when status changes for `voice` applications. Always required for `voice` applications.
                   type: string
                   example: "https://example.com/webhooks/event"
@@ -125,7 +125,7 @@ paths:
                   example: POST
                 status_url:
                   description: >-
-                    Nexmo sends event information asynchronously to this URL
+                    Vonage sends event information asynchronously to this URL
                     when status changes. Required for `messages` type applications only.
                   type: string
                   example: "https://example.com/webhooks/status"
@@ -137,7 +137,7 @@ paths:
                   example: POST
                 inbound_url:
                   description: >-
-                    Nexmo sends a request to this URL when an inbound message
+                    Vonage sends a request to this URL when an inbound message
                     is received. Required for `messages` type applications only.
                   type: string
                   example: "https://example.com/webhooks/inbound"
@@ -198,7 +198,7 @@ paths:
                   example: UpdatedApplication
                 type:
                   description: >-
-                    The Nexmo product or products that you access with this application.
+                    The Vonage API product or products that you access with this application.
                     Currently `voice` and `messages` application types are supported. You 
                     can't change the type of application.
                   type: string
@@ -209,7 +209,7 @@ paths:
                 answer_url:
                   description: >-
                     The URL where your webhook delivers the Nexmo Call Control Object
-                    that governs this call. As soon as your user answers a call Nexmo
+                    that governs this call. As soon as your user answers a call Vonage
                     makes a request to `answer_url`.
                   type: string
                   format: url
@@ -223,7 +223,7 @@ paths:
                   example: GET
                 event_url:
                   description: >-
-                    Nexmo sends event information asynchronously to this URL when status
+                    Vonage sends event information asynchronously to this URL when status
                     changes.
                   type: string
                   format: url
@@ -257,7 +257,7 @@ components:
       name: app_id
       in: path
       required: true
-      description: The ID allocated to your application by Nexmo.
+      description: The ID allocated to your application by Vonage.
       schema:
         type: string
       example: aaaaaaaa-bbbb-cccc-dddd-0123456789ab
@@ -306,7 +306,7 @@ components:
           example: /v1/applications/aaaaaaaa-bbbb-cccc-dddd-0123456789ab
     voice:
       description: >-
-        The Nexmo product that you access with this application.
+        The Vonage API product that you access with this application.
       type: object
       properties:
         webhooks:
@@ -329,8 +329,8 @@ components:
                 description: >-
                   `answer_url`: The URL where your webhook delivers the Nexmo
                   Call Control Object that governs this call. As soon as your
-                  user answers a call Nexmo makes a request to answer_url.
-                  `event_url`: Nexmo sends event information asynchronously to
+                  user answers a call Vonage makes a request to answer_url.
+                  `event_url`: Vonage sends event information asynchronously to
                   this URL when status changes.
                 format: url
                 example: "https://example.com/webhooks/answer"
@@ -345,7 +345,7 @@ components:
                 example: GET
     messages:
       description: >-
-        The Nexmo product that you access with this application.
+        The Vonage API product that you access with this application.
       type: object
       properties:
         webhooks:
@@ -381,7 +381,7 @@ components:
                 example: POST
     keys:
       description: >-
-        The Nexmo product that you access with this application.
+        The Vonage API product that you access with this application.
       type: object
       properties:
         public_key:
@@ -429,7 +429,7 @@ components:
       type: object
       properties:
         id:
-          description: The ID allocated to your application by Nexmo.
+          description: The ID allocated to your application by Vonage.
           type: string
           example: aaaaaaaa-bbbb-cccc-dddd-0123456789ab
         name:

--- a/definitions/audit.yml
+++ b/definitions/audit.yml
@@ -2,9 +2,9 @@ openapi: "3.0.0"
 
 info:
   version: 1.0.3
-  title: Nexmo Audit API
+  title: Vonage Audit API
   description: >
-    Nexmo's Audit API allows you to view details of changes to your account. More information is available at <https://developer.nexmo.com/audit/overview>.
+    The Vonage Audit API allows you to view details of changes to your account. More information is available at <https://developer.nexmo.com/audit/overview>.
 
     _Please note that the Audit API is currently in Beta_
   x-label: Beta
@@ -27,7 +27,7 @@ paths:
       summary: Retrieve audit events
       description: >
         Get a series of audit events describing changes made to your
-        Nexmo account over time.
+        Vonage API account over time.
       parameters:
         - name: event_type
           description: Filter results by this event type.
@@ -243,7 +243,7 @@ components:
           example: 1234567
         account_id:
           type: string
-          description: "The NEXMO_API_KEY of the Nexmo account that the audit event is associated with."
+          description: "The NEXMO_API_KEY of the Vonage API account that the audit event is associated with."
           example: "abcd1234"
         source:
           type: string

--- a/definitions/conversation.v2.yml
+++ b/definitions/conversation.v2.yml
@@ -3,8 +3,8 @@ servers:
   - url: "https://api.nexmo.com/v0.2"
 info:
   version: 1.0.0
-  title: Nexmo Conversation API
-  description: "The Nexmo Conversation API enables you to build conversation features where communication can take place across multiple mediums including IP Messaging, PSTN Voice, SMS and WebRTC Audio and Video. The context of the conversations is maintained though each communication event taking place within a conversation, no matter the medium."
+  title: Vonage Conversation API
+  description: "The Vonage Conversation API enables you to build conversation features where communication can take place across multiple mediums including IP Messaging, PSTN Voice, SMS and WebRTC Audio and Video. The context of the conversations is maintained though each communication event taking place within a conversation, no matter the medium."
   contact:
     name: Nexmo DevRel
     email: devrel@nexmo.com


### PR DESCRIPTION
# Description

Lots of Nexmo to Vonage changes!

<!--

The following will be used in our release notes and public changelog. Communicate well!

Example:

# New 

* Added new `/foobar/sync` endpoint to toggle widget status
* The `GET /v1/calls` endpoint now supports a `to` query parameter to filter calls to a single number

# Fixes

* Add HTTP 401 and 403 error code documentation to the `/v1/calls` endpoint
-->

# Checklist

- [ ] version number incremented (in the `info` section of the spec)
