### PR TITLE
Messages API rebranding

### DIFF
--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -1,11 +1,11 @@
 openapi: "3.0.0"
 info:
-  version: 0.3.11
+  version: 0.3.12
   title: Messages API
   description: "The Messaging API is a new API that consolidates all messaging channels. It encapsulates a user (developer) from having to use multiple APIs to interact with our various channels such as SMS, MMS, Viber, Facebook Messenger, etc. The API normalises information across all channels to abstracted to, from and content. This API is currently in Beta."
   contact:
-    name: Nexmo DevRel
-    email: devrel@nexmo.com
+    name: Vonage DevRel
+    email: devrel@vonage.com
     url: "https://developer.nexmo.com/"
   x-label: Beta
 servers:
@@ -418,7 +418,7 @@ components:
       properties:
         category:
           type: string
-          description: The use of different category tags enables the business to send messages for different use cases. For Facebook Messenger they need to comply with their [Messaging Types policy](https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types). Nexmo maps our `category` to their `messaging_type`. If `message_tag` is used, then an additional `tag` for that type is mandatory. By default Nexmo sends the `response` category to Facebook Messenger.
+          description: The use of different category tags enables the business to send messages for different use cases. For Facebook Messenger they need to comply with their [Messaging Types policy](https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types). Vonage maps our `category` to their `messaging_type`. If `message_tag` is used, then an additional `tag` for that type is mandatory. By default Vonage sends the `response` category to Facebook Messenger.
           example: update
           enum:
             - response
@@ -823,7 +823,7 @@ components:
       type: object
       properties:
         category:
-          description: "The use of different category tags enables the business to send messages for different use cases. For Viber Service Messages the first message sent from a business to a user must be personal, informative & a targeted message - not promotional. By default Nexmo sends the `transaction` category to Viber Service Messages."
+          description: "The use of different category tags enables the business to send messages for different use cases. For Viber Service Messages the first message sent from a business to a user must be personal, informative & a targeted message - not promotional. By default Vonage sends the `transaction` category to Viber Service Messages."
           type: string
           example: "transaction"
           enum:
@@ -836,7 +836,7 @@ components:
           minimum: 30
           maximum: 259200
         type:
-          description: 'Viber-specific type definition. To use "template", please contact Nexmo Account Manager to setup your templates. To find out more please visit [nexmo.com/products/messages](https://www.nexmo.com/products/messages).'
+          description: 'Viber-specific type definition. To use "template", please contact Vonage Account Manager to setup your templates. To find out more please visit [vonage.com/products/messages](https://www.vonage.com/communications-apis/messages/).'
           type: string
           example: "template"
     textMessageViberContent:
@@ -1282,7 +1282,7 @@ components:
                 - viber_service_msg
             id:
               type: string
-              description: This is your Service Message ID given to you by Nexmo Account Manager. To find out more please visit [nexmo.com/products/messages](https://www.vonage.com/communications-apis/messages/).
+              description: This is your Service Message ID given to you by Vonage Account Manager. To find out more please visit [vonage.com/products/messages](https://www.vonage.com/communications-apis/messages/).
               example: '654321'
         from:
           required:
@@ -1338,7 +1338,7 @@ components:
                 - viber_service_msg
             id:
               type: string
-              description: This is your Service Message ID given to you by Nexmo Account Manager. To find out more please visit [nexmo.com/products/messages](https://www.vonage.com/communications-apis/messages/).
+              description: This is your Service Message ID given to you by Vonage Account Manager. To find out more please visit [vonage.com](https://www.vonage.com/communications-apis/messages/).
               example: '654321'
     channelOptionsViber:
       allOf:
@@ -1415,11 +1415,11 @@ components:
             code:
               type: integer
               example: 1300
-              description: The error code. See [our errors list](https://developer.nexmo.com/api-errors/messages-olympus) for a list of possible errors
+              description: The error code. See [our errors list](/api-errors/messages-olympus) for a list of possible errors
             reason:
               type: string
               example: "Not part of the provider network"
-              description: Text describing the error. See [our errors list](https://developer.nexmo.com/api-errors/messages-olympus) for a list of possible errors
+              description: Text describing the error. See [our errors list](/api-errors/messages-olympus) for a list of possible errors
         usage:
           type: object
           properties:
@@ -1488,7 +1488,7 @@ components:
 
             **Messenger**: This value should be the `to.id` value you received in the inbound messenger event.
 
-            **Viber**: This is your Service Message ID given to you by Nexmo Account Manager. To find out more please visit [nexmo.com/products/messages](https://www.nexmo.com/products/messages).
+            **Viber**: This is your Service Message ID given to you by Vonage Account Manager. To find out more please visit [vonage.com](https://www.vonage.com/communications-apis/messages/).
 
           type: string
           minLength: 1
@@ -1502,7 +1502,7 @@ components:
           description: |
             **SMS**: The phone number of the message recipient in the [E.164](https://en.wikipedia.org/wiki/E.164) format. Don't use a leading + or 00 when entering a phone number, start with the country code, for example, 447700900000.
 
-            **WhatsApp**: This is your WhatsApp Business Number  given to you by Nexmo Account Manager. To find out more please visit [nexmo.com/products/messages](https://www.nexmo.com/products/messages).
+            **WhatsApp**: This is your WhatsApp Business Number  given to you by Vonage Account Manager. To find out more please visit [vonage.com](https://www.vonage.com/communications-apis/messages/).
 
             **MMS**: US shortcode
     
@@ -1633,7 +1633,7 @@ x-errors:
     description: TTL was activated  -  TTL was activated, no callbacks and no charge will be issued.
 
   "1370":
-    description: Expired access Token - Please reauthenticate your Facebook Page with Nexmo.
+    description: Expired access Token - Please reauthenticate your Facebook Page with Vonage.
 
   "1380":
     description: Invalid resource - Please check that the URL your provided to your resrouce is accesible and valid.

--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -1338,7 +1338,7 @@ components:
                 - viber_service_msg
             id:
               type: string
-              description: This is your Service Message ID given to you by Vonage Account Manager. To find out more please visit [vonage.com](https://www.vonage.com/communications-apis/messages/).
+              description: This is your Service Message ID given to you by your Vonage Account Manager. To find out more please visit [vonage.com](https://www.vonage.com/communications-apis/messages/).
               example: '654321'
     channelOptionsViber:
       allOf:

--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -1488,7 +1488,7 @@ components:
 
             **Messenger**: This value should be the `to.id` value you received in the inbound messenger event.
 
-            **Viber**: This is your Service Message ID given to you by Vonage Account Manager. To find out more please visit [vonage.com](https://www.vonage.com/communications-apis/messages/).
+            **Viber**: This is your Service Message ID given to you by your Vonage Account Manager. To find out more please visit [vonage.com](https://www.vonage.com/communications-apis/messages/).
 
           type: string
           minLength: 1

--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -1502,7 +1502,7 @@ components:
           description: |
             **SMS**: The phone number of the message recipient in the [E.164](https://en.wikipedia.org/wiki/E.164) format. Don't use a leading + or 00 when entering a phone number, start with the country code, for example, 447700900000.
 
-            **WhatsApp**: This is your WhatsApp Business Number  given to you by Vonage Account Manager. To find out more please visit [vonage.com](https://www.vonage.com/communications-apis/messages/).
+            **WhatsApp**: This is your WhatsApp Business Number given to you by your Vonage Account Manager. To find out more please visit [vonage.com](https://www.vonage.com/communications-apis/messages/).
 
             **MMS**: US shortcode
     

--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   version: 0.3.12
   title: Messages API
-  description: "The Messaging API is a new API that consolidates all messaging channels. It encapsulates a user (developer) from having to use multiple APIs to interact with our various channels such as SMS, MMS, Viber, Facebook Messenger, etc. The API normalises information across all channels to abstracted to, from and content. This API is currently in Beta."
+  description: "The Messages API enables you to send messages to customers via their preferred channels (currently Facebook Messenger, WhatsApp, Viber, and SMS/MMS) using a single API. The Messages API is currently in Beta."
   contact:
     name: Vonage DevRel
     email: devrel@vonage.com


### PR DESCRIPTION
# Description

Replaced Nexmo references to Vonage.

<!--

The following will be used in our release notes and public changelog. Communicate well!

Example:

# New 

* Added new `/foobar/sync` endpoint to toggle widget status
* The `GET /v1/calls` endpoint now supports a `to` query parameter to filter calls to a single number

# Fixes

* Add HTTP 401 and 403 error code documentation to the `/v1/calls` endpoint
-->

# Checklist

- [x] version number incremented (in the `info` section of the spec)
