### PR TITLE
Dispatch API rebrand

### DIFF
--- a/definitions/dispatch.yml
+++ b/definitions/dispatch.yml
@@ -1,11 +1,11 @@
 openapi: "3.0.0"
 info:
-  version: 0.3.2
+  version: 0.3.3
   title: Dispatch API
   description: "The Dispatch API enables the developer to specify a multiple message workflow. A workflow follows a template. The first one we are adding is the failover template. The failover template instructs the Messages API to first send a message to the specified channel. If that message fails immediately or if the condition_status is not reached within the given time period the next message is sent. The developer will also receive status webhooks from the messages resource for each delivery and read event. This API is currently in Beta."
   contact:
-    name: Nexmo DevRel
-    email: devrel@nexmo.com
+    name: Vonage DevRel
+    email: devrel@vonage.com
     url: "https://developer.nexmo.com/"
   x-label: Beta
 servers:
@@ -156,7 +156,7 @@ components:
 
             **Messenger**: This value should be the `to.id` value you received in the inbound messenger event.
 
-            **Viber**: This is your Service Message ID given to you by Nexmo Account Manager. To find out more please visit [nexmo.com/products/messages](https://www.nexmo.com/products/messages).
+            **Viber**: This is your Service Message ID given to you by Vonage Account Manager. To find out more please visit [vonage.com](https://www.vonage.com/communications-apis/messages/).
 
             **SMS**: **MMS**: or **WhatsApp** This value is not required.
           type: string
@@ -171,7 +171,7 @@ components:
           description: |
             **SMS**: or **MMS**: The phone number of the message sender in the [E.164](https://en.wikipedia.org/wiki/E.164) format.
 
-            **WhatsApp**: This is your WhatsApp Business Number  given to you by Nexmo Account Manager. To find out more please visit [nexmo.com/products/messages](https://www.nexmo.com/products/messages).
+            **WhatsApp**: This is your WhatsApp Business Number  given to you by Vonage Account Manager. To find out more please visit [vonage.com](https://www.vonage.com/communications-apis/messages/).
 
             **Messenger**: or **Viber**: This value is not required.
 
@@ -218,7 +218,7 @@ components:
               type: string
               minLength: 1
               maxLength: 4096
-              example: "Nexmo Verification code: 64873. Valid for 10 minutes."
+              example: "Vonage Verification code: 64873. Valid for 10 minutes."
             image:
               $ref: "#/components/schemas/ImageProperty"
             audio:
@@ -233,7 +233,7 @@ components:
           type: object
           properties:
             category:
-              description: "The use of different category tags enables the business to send messages for different use cases. For Viber Service Messages the first message sent from a business to a user must be personal, informative and a targeted message - not promotional. By default Nexmo sends the `transaction` category to Viber Service Messages."
+              description: "The use of different category tags enables the business to send messages for different use cases. For Viber Service Messages the first message sent from a business to a user must be personal, informative and a targeted message - not promotional. By default Vonage sends the `transaction` category to Viber Service Messages."
               type: string
               example: "transaction"
               enum:
@@ -249,7 +249,7 @@ components:
           type: object
           properties:
             category:
-              description: "The use of different category tags enables the business to send messages for different use cases. For Facebook Messenger they need to comply with their [Messaging Types policy]( https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types). Nexmo maps our `category` to their `messaging_type`. If `message_tag` is used, then an additional `tag` for that type is mandatory. By default Nexmo sends the `response` category to Facebook Messenger."
+              description: "The use of different category tags enables the business to send messages for different use cases. For Facebook Messenger they need to comply with their [Messaging Types policy]( https://developers.facebook.com/docs/messenger-platform/send-messages#messaging_types). Vonage maps our `category` to their `messaging_type`. If `message_tag` is used, then an additional `tag` for that type is mandatory. By default Vonage sends the `response` category to Facebook Messenger."
               type: string
               example: "message_tag"
               enum:
@@ -358,7 +358,7 @@ components:
         name:
           type: string
           description: "The name of the template."
-          example: "whatsapp:hsm:technology:nexmo:verify"
+          example: "whatsapp:hsm:technology:vonage:verify"
         parameters:
           type: array
           items:
@@ -468,11 +468,11 @@ components:
             code:
               type: integer
               example: 1300
-              description: The error code. See [our errors list](https://developer.nexmo.com/api-errors/messages-olympus) for a list of possible errors
+              description: The error code. See [our errors list](/api-errors/messages-olympus) for a list of possible errors
             reason:
               type: string
               example: "Not part of the provider network"
-              description: Text describing the error. See [our errors list](https://developer.nexmo.com/api-errors/messages-olympus) for a list of possible errors
+              description: Text describing the error. See [our errors list](/api-errors/messages-olympus) for a list of possible errors
         usage:
           type: object
           properties:

--- a/definitions/dispatch.yml
+++ b/definitions/dispatch.yml
@@ -156,7 +156,7 @@ components:
 
             **Messenger**: This value should be the `to.id` value you received in the inbound messenger event.
 
-            **Viber**: This is your Service Message ID given to you by Vonage Account Manager. To find out more please visit [vonage.com](https://www.vonage.com/communications-apis/messages/).
+            **Viber**: This is your Service Message ID given to you by your Vonage Account Manager. To find out more please visit [vonage.com](https://www.vonage.com/communications-apis/messages/).
 
             **SMS**: **MMS**: or **WhatsApp** This value is not required.
           type: string
@@ -171,7 +171,7 @@ components:
           description: |
             **SMS**: or **MMS**: The phone number of the message sender in the [E.164](https://en.wikipedia.org/wiki/E.164) format.
 
-            **WhatsApp**: This is your WhatsApp Business Number  given to you by Vonage Account Manager. To find out more please visit [vonage.com](https://www.vonage.com/communications-apis/messages/).
+            **WhatsApp**: This is your WhatsApp Business Number given to you by your Vonage Account Manager. To find out more please visit [vonage.com](https://www.vonage.com/communications-apis/messages/).
 
             **Messenger**: or **Viber**: This value is not required.
 


### PR DESCRIPTION
# Description

Replaced Nexmo references with Vonage.

<!--

The following will be used in our release notes and public changelog. Communicate well!

Example:

# New 

* Added new `/foobar/sync` endpoint to toggle widget status
* The `GET /v1/calls` endpoint now supports a `to` query parameter to filter calls to a single number

# Fixes

* Add HTTP 401 and 403 error code documentation to the `/v1/calls` endpoint
-->

# Checklist

- [x] version number incremented (in the `info` section of the spec)
