### PR TITLE
Add subaccounts transfer-number API spec

### DIFF
--- a/definitions/subaccounts.yml
+++ b/definitions/subaccounts.yml
@@ -40,7 +40,7 @@ paths:
         "403":
           $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/AccountIdNotFoundError"
     post:
       summary: Create subaccount
       operationId: createSubAccount
@@ -75,7 +75,7 @@ paths:
         "403":
           $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/AccountIdNotFoundError"
         "422":
           $ref: "#/components/responses/UnprocessableEntityError"
   /{api_key}/subaccounts/{subaccount_key}:
@@ -113,7 +113,7 @@ paths:
         "403":
           $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/AccountIdNotFoundError"
     patch:
       summary: Modify a subaccount
       operationId: modifySubaccount
@@ -154,7 +154,7 @@ paths:
         "403":
           $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/AccountIdNotFoundError"
         "422":
           $ref: "#/components/responses/UnprocessableEntityError"
   /{api_key}/credit-transfers:
@@ -206,7 +206,7 @@ paths:
         "403":
           $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/AccountIdNotFoundError"
     post:
       summary: Transfer credit
       operationId: transferCredit
@@ -241,7 +241,7 @@ paths:
         "403":
           $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/AccountIdNotFoundError"
         "422":
           $ref: "#/components/responses/UnprocessableEntityError"
   /{api_key}/balance-transfers:
@@ -293,7 +293,7 @@ paths:
         "403":
           $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/AccountIdNotFoundError"
     post:
       summary: Transfer balance
       description: >
@@ -329,7 +329,7 @@ paths:
         "403":
           $ref: "#/components/responses/ForbiddenError"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          $ref: "#/components/responses/AccountIdNotFoundError"
         "422":
           $ref: "#/components/responses/UnprocessableEntityError"
   /{api_key}/transfer-number:
@@ -373,7 +373,15 @@ paths:
                   - $ref: "#/components/schemas/UnprovisionedErrorResponse"
                   - $ref: "#/components/schemas/InvalidNumberTransferErrorResponse"
         "404":
-          $ref: "#/components/responses/NotFoundError"
+          description: Action is forbidden
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/responses/AccountIdNotFoundError/content/application~1json/schema"
+                  - $ref: "#/components/schemas/ShortcodeNotFound"
+        "409":
+          $ref: "#/components/responses/NumberTransferConflictResponse"
         "422":
           $ref: "#/components/responses/UnprocessableEntityError"
 tags:
@@ -417,11 +425,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/UnprovisionedErrorResponse"
-    NotFoundError:
+    AccountIdNotFoundError:
       description: The account ID provided does not exist in our system or you do not have access
       content:
         application/json:
           schema:
+            description: Invalid API Key
             type: object
             required:
               - type
@@ -441,6 +450,30 @@ components:
               instance:
                 type: string
                 example: "158b8f199c45014ab7b08bfe9cc1c12c"
+    NumberTransferConflictResponse:
+      description: Conflict
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - type
+              - title
+              - detail
+              - instance
+            properties:
+              type:
+                type: string
+                example: "https://developer.nexmo.com/api-errors/subaccounts#transfer-conflict"
+              title:
+                type: string
+                example: "Transfer Conflict"
+              detail:
+                type: string
+                example: "Could not transfer number {number} from account {from} to {to} - ShortCode is already owned by requesting account"
+              instance:
+                type: string
+                example: "158b8f199c45014ab7b08bfe9cc1c12c"
     UnprocessableEntityError:
       description: Validation Error
       content:
@@ -456,7 +489,7 @@ components:
             properties:
               type:
                 type: string
-                example: "https://developer.nexmo.com/api-errors/account/subaccounts#validation"
+                example: "https://developer.nexmo.com/api-errors/subaccounts#validation"
               title:
                 type: string
                 example: "Bad Request"
@@ -523,6 +556,27 @@ components:
         instance:
           type: string
           example: "158b8f199c45014ab7b08bfe9cc1c12c"
+    ShortcodeNotFound:
+      description: Shortcode Not Found
+      type: object
+      required:
+        - type
+        - title
+        - detail
+        - instance
+      properties:
+        type:
+          type: string
+          example: "https://developer.nexmo.com/api-errors/subaccounts#missing-number-transfer"
+        title:
+          type: string
+          example: "Invalid Number Transfer"
+        detail:
+          type: string
+          example: "Could not transfer number {number} from account {from} to {to} - ShortCode not found"
+        instance:
+          type: string
+          example: "158b8f199c45014ab7b08bfe9cc1c12c"
     InvalidNumberTransferErrorResponse:
       description: Invalid Transfer
       type: object
@@ -534,13 +588,13 @@ components:
       properties:
         type:
           type: string
-          example: "https://developer.nexmo.com/api-errors#invalid-number-transfer"
+          example: "https://developer.nexmo.com/api-errors/subaccounts#invalid-number-transfer"
         title:
           type: string
           example: "Invalid Number Transfer"
         detail:
           type: string
-          example: "Failed to perform transfer number {number} from account {from} to {to} - Shortcode not found"
+          example: "Failed to perform transfer number {number} from account {from} to {to} - The relationship between these two accounts does not allow for number transfer"
         instance:
           type: string
           example: "158b8f199c45014ab7b08bfe9cc1c12c"

--- a/definitions/subaccounts.yml
+++ b/definitions/subaccounts.yml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers:
   - url: "https://api.nexmo.com/accounts"
 info:
-  version: 1.0.6
+  version: 1.0.7
   title: Subaccounts API
   description: >-
     The Nexmo Subaccounts API enables you to create subaccounts under your primary account. Subaccounts facilitate differential product configuration, reporting, and billing. The Subaccounts API is released initially with restricted availability. You can read more about the API in the [Subaccounts documentation](/account/subaccounts/overview).

--- a/definitions/subaccounts.yml
+++ b/definitions/subaccounts.yml
@@ -642,11 +642,6 @@ components:
             The date and time when the balance transfer was executed
     TransferNumberResponse:
       properties:
-        number_transfer_id:
-          example: "07b5-46e1-a527-85530e625800"
-          type: string
-          description: >-
-            Unique number transfer ID
         number:
           example: 235077036
           type: number
@@ -667,11 +662,6 @@ components:
           type: string
           description: >-
             Account the number is transferred to
-        created_at:
-          example: "2019-03-02T16:34:49Z"
-          type: string
-          description: >-
-            The date and time when the number transfer was executed
     ListCreditTransfersResponse:
       properties:
         _embedded:

--- a/definitions/subaccounts.yml
+++ b/definitions/subaccounts.yml
@@ -365,7 +365,13 @@ paths:
         "401":
           $ref: "#/components/responses/UnauthorizedError"
         "403":
-          $ref: "#/components/responses/ForbiddenError"
+          description: Action is forbidden
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/UnprovisionedErrorResponse"
+                  - $ref: "#/components/schemas/InvalidNumberTransferErrorResponse"
         "404":
           $ref: "#/components/responses/NotFoundError"
         "422":
@@ -410,25 +416,7 @@ components:
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - type
-              - title
-              - detail
-              - instance
-            properties:
-              type:
-                type: string
-                example: "https://developer.nexmo.com/api-errors#unprovisioned"
-              title:
-                type: string
-                example: "Authorisation error"
-              detail:
-                type: string
-                example: "Account acc6111f is not provisioned to access Subaccount Provisioning API"
-              instance:
-                type: string
-                example: "158b8f199c45014ab7b08bfe9cc1c12c"
+            $ref: "#/components/schemas/UnprovisionedErrorResponse"
     NotFoundError:
       description: The account ID provided does not exist in our system or you do not have access
       content:
@@ -514,6 +502,48 @@ components:
                 type: string
                 example: "158b8f199c45014ab7b08bfe9cc1c12c"
   schemas:
+    UnprovisionedErrorResponse:
+      description: Unprovisioned
+      type: object
+      required:
+        - type
+        - title
+        - detail
+        - instance
+      properties:
+        type:
+          type: string
+          example: "https://developer.nexmo.com/api-errors#unprovisioned"
+        title:
+          type: string
+          example: "Authorisation error"
+        detail:
+          type: string
+          example: "Account acc6111f is not provisioned to access Subaccount Provisioning API"
+        instance:
+          type: string
+          example: "158b8f199c45014ab7b08bfe9cc1c12c"
+    InvalidNumberTransferErrorResponse:
+      description: Invalid Transfer
+      type: object
+      required:
+        - type
+        - title
+        - detail
+        - instance
+      properties:
+        type:
+          type: string
+          example: "https://developer.nexmo.com/api-errors#invalid-number-transfer"
+        title:
+          type: string
+          example: "Invalid Number Transfer"
+        detail:
+          type: string
+          example: "Failed to perform transfer number {number} from account {from} to {to} - Shortcode not found"
+        instance:
+          type: string
+          example: "158b8f199c45014ab7b08bfe9cc1c12c"
     SubaccountsAllResponse:
       properties:
         _embedded:
@@ -643,8 +673,8 @@ components:
     TransferNumberResponse:
       properties:
         number:
-          example: 235077036
-          type: number
+          example: "235077036"
+          type: string
           description: >-
             Number transfered
         country:
@@ -725,7 +755,7 @@ components:
         - amount
     TransferNumberRequest:
       type: object
-      properties: 
+      properties:
         from:
           type: string
           example: "7c9738e6"

--- a/definitions/subaccounts.yml
+++ b/definitions/subaccounts.yml
@@ -640,24 +640,6 @@ components:
           type: string
           description: >-
             The date and time when the balance transfer was executed
-    ListCreditTransfersResponse:
-      properties:
-        _embedded:
-          type: object
-          properties:
-            credit-transfers:
-              type: array
-              items:
-                $ref: "#/components/schemas/TransferCreditResponse"
-    ListBalanceTransfersResponse:
-      properties:
-        _embedded:
-          type: object
-          properties:
-            balance_transfers:
-              type: array
-              items:
-                $ref: "#/components/schemas/TransferBalanceResponse"
     TransferNumberResponse:
       properties:
         number_transfer_id:
@@ -690,6 +672,24 @@ components:
           type: string
           description: >-
             The date and time when the number transfer was executed
+    ListCreditTransfersResponse:
+      properties:
+        _embedded:
+          type: object
+          properties:
+            credit-transfers:
+              type: array
+              items:
+                $ref: "#/components/schemas/TransferCreditResponse"
+    ListBalanceTransfersResponse:
+      properties:
+        _embedded:
+          type: object
+          properties:
+            balance_transfers:
+              type: array
+              items:
+                $ref: "#/components/schemas/TransferBalanceResponse"
     NewSubaccountRequest:
       type: object
       required:

--- a/definitions/subaccounts.yml
+++ b/definitions/subaccounts.yml
@@ -670,6 +670,11 @@ components:
           type: number
           description: >-
             Number transfered
+        country:
+          example: "GB"
+          type: string
+          description: >-
+            The two character country code in ISO 3166-1 alpha-2 format
         from:
           example: "7c9738e6"
           type: string

--- a/definitions/subaccounts.yml
+++ b/definitions/subaccounts.yml
@@ -332,11 +332,49 @@ paths:
           $ref: "#/components/responses/NotFoundError"
         "422":
           $ref: "#/components/responses/UnprocessableEntityError"
+  /{api_key}/transfer-number:
+    post:
+      summary: Transfer number
+      operationId: transferNumber
+      description: >
+        Transfer number from one account to another.
+      tags:
+        - Transfers
+      security:
+        - basicAuth: []
+      parameters:
+        - name: api_key
+          in: path
+          description: ID of the primary account.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TransferNumberRequest"
+      responses:
+        "200":
+          description: Number transfer response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TransferNumberResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          $ref: "#/components/responses/NotFoundError"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntityError"
 tags:
   - name: Subaccount Management
     description: This section shows how you can create, retrieve and modify subaccounts of a primary account.
   - name: Transfers
-    description: This section shows how you execute credit and balance transfers, as well as viewing past transactions.
+    description: This section shows how you execute credit, balance and number transfers, as well as viewing past transactions.
 components:
   securitySchemes:
     basicAuth:
@@ -620,6 +658,33 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/TransferBalanceResponse"
+    TransferNumberResponse:
+      properties:
+        number_transfer_id:
+          example: "07b5-46e1-a527-85530e625800"
+          type: string
+          description: >-
+            Unique number transfer ID
+        number:
+          example: 235077036
+          type: number
+          description: >-
+            Number transfered
+        from:
+          example: "7c9738e6"
+          type: string
+          description: >-
+            Account the number is transferred from
+        to:
+          example: "ad6dc56f"
+          type: string
+          description: >-
+            Account the number is transferred to
+        created_at:
+          example: "2019-03-02T16:34:49Z"
+          type: string
+          description: >-
+            The date and time when the number transfer was executed
     NewSubaccountRequest:
       type: object
       required:
@@ -663,6 +728,21 @@ components:
         - from
         - to
         - amount
+    TransferNumberRequest:
+      type: object
+      properties: 
+        from:
+          type: string
+          example: "7c9738e6"
+        to:
+          type: string
+          example: "ad6dc56f"
+        number:
+          type: number
+          example: "23507703696"
+        country:
+          type: string
+          example: "GB"
 
 x-errors:
   validation:


### PR DESCRIPTION
# Description

# New 

* Added new `/accounts/:api_key/transfer-number` endpoint to transfer a number between two subaccounts

# Checklist

- [ ] version number incremented (in the `info` section of the spec)
