### PR TITLE
Added new fields to send SMS to comply with DLT (India) regulations

### DIFF
--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -202,11 +202,11 @@ components:
           type: string
           example: customer1234
         entity-id:
-          description: "**Advanced**: An string only required when needing to meet certain country regulations by providing this field when making an SMS request. For more information please refer to the [Country-Specific Outbound SMS Features](https://help.nexmo.com/hc/en-us/articles/115011781468)"
+          description: "**Advanced**: A string only required when needing to meet certain country regulations by providing this field when making an SMS request. For more information please refer to the [Country-Specific Outbound SMS Features](https://help.nexmo.com/hc/en-us/articles/115011781468)"
           type: string
           example: "1101456324675322134"
         content-id:
-          description: "**Advanced**: An string only required when needing to meet certain country regulations by providing this field when making an SMS request. For more information please refer to the [Country-Specific Outbound SMS Features](https://help.nexmo.com/hc/en-us/articles/115011781468)"
+          description: "**Advanced**: A string only required when needing to meet certain country regulations by providing this field when making an SMS request. For more information please refer to the [Country-Specific Outbound SMS Features](https://help.nexmo.com/hc/en-us/articles/115011781468)"
           type: string
           example: "1107457532145798767"
     Error:

--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -201,6 +201,14 @@ components:
           description: "**Advanced**: An optional string used to identify separate accounts using the SMS endpoint for billing purposes. To use this feature, please email [support@nexmo.com](mailto:support@nexmo.com)"
           type: string
           example: customer1234
+        entity-id:
+          description: "**Advanced**: An string only required when needing to meet certain country regulations by providing this field when making an SMS request. For more information please refer to the [Country-Specific Outbound SMS Features](https://help.nexmo.com/hc/en-us/articles/115011781468)"
+          type: string
+          example: "1101456324675322134"
+        content-id:
+          description: "**Advanced**: An string only required when needing to meet certain country regulations by providing this field when making an SMS request. For more information please refer to the [Country-Specific Outbound SMS Features](https://help.nexmo.com/hc/en-us/articles/115011781468)"
+          type: string
+          example: "1107457532145798767"
     Error:
       description: Error
       type: object

--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -206,7 +206,7 @@ components:
           type: string
           example: "1101456324675322134"
         content_id:
-          description: "**Advanced**: A string only required when needing to meet certain country regulations by providing this field when making an SMS request. For more information please refer to the [Country-Specific Outbound SMS Features](https://help.nexmo.com/hc/en-us/articles/115011781468)"
+          description: "**Advanced**: A string parameter that satisfies regulatory requirements when sending an SMS to specific countries. For more information please refer to the [Country-Specific Outbound SMS Features](https://help.nexmo.com/hc/en-us/articles/115011781468)"
           type: string
           example: "1107457532145798767"
     Error:

--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -201,11 +201,11 @@ components:
           description: "**Advanced**: An optional string used to identify separate accounts using the SMS endpoint for billing purposes. To use this feature, please email [support@nexmo.com](mailto:support@nexmo.com)"
           type: string
           example: customer1234
-        entity_id:
+        entity-id:
           description: "**Advanced**: A string parameter that satisfies regulatory requirements when sending an SMS to specific countries. For more information please refer to the [Country-Specific Outbound SMS Features](https://help.nexmo.com/hc/en-us/articles/115011781468)"
           type: string
           example: "1101456324675322134"
-        content_id:
+        content-id:
           description: "**Advanced**: A string parameter that satisfies regulatory requirements when sending an SMS to specific countries. For more information please refer to the [Country-Specific Outbound SMS Features](https://help.nexmo.com/hc/en-us/articles/115011781468)"
           type: string
           example: "1107457532145798767"

--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -202,7 +202,7 @@ components:
           type: string
           example: customer1234
         entity_id:
-          description: "**Advanced**: A string only required when needing to meet certain country regulations by providing this field when making an SMS request. For more information please refer to the [Country-Specific Outbound SMS Features](https://help.nexmo.com/hc/en-us/articles/115011781468)"
+          description: "**Advanced**: A string parameter that satisfies regulatory requirements when sending an SMS to specific countries. For more information please refer to the [Country-Specific Outbound SMS Features](https://help.nexmo.com/hc/en-us/articles/115011781468)"
           type: string
           example: "1101456324675322134"
         content_id:

--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: 1.0.9
+  version: 1.0.10
   title: SMS API
   description: With the SMS API you can send SMS from your account and lookup messages both messages that you've sent as well as messages sent to your virtual numbers. Numbers are specified in E.164 format. More SMS API documentation is at <https://developer.nexmo.com/messaging/sms/overview>
   contact:

--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -201,11 +201,11 @@ components:
           description: "**Advanced**: An optional string used to identify separate accounts using the SMS endpoint for billing purposes. To use this feature, please email [support@nexmo.com](mailto:support@nexmo.com)"
           type: string
           example: customer1234
-        entity-id:
+        entity_id:
           description: "**Advanced**: A string only required when needing to meet certain country regulations by providing this field when making an SMS request. For more information please refer to the [Country-Specific Outbound SMS Features](https://help.nexmo.com/hc/en-us/articles/115011781468)"
           type: string
           example: "1101456324675322134"
-        content-id:
+        content_id:
           description: "**Advanced**: A string only required when needing to meet certain country regulations by providing this field when making an SMS request. For more information please refer to the [Country-Specific Outbound SMS Features](https://help.nexmo.com/hc/en-us/articles/115011781468)"
           type: string
           example: "1107457532145798767"


### PR DESCRIPTION
# Description

**Note**, this should not be merged until Monday due to this being when the feature is going to be deployed.

To make sure that our APIs meet new regulations, we're adding two new fields to the send-sms endpoint. These are `entity-id` and `content-id`. The first of these regulations is DLT, which is an Indian regulation, but we're expecting more regulations from other countries in the future, so these two fields are being kept as generic as possible. For more information on DLT please go to: https://help.nexmo.com/hc/en-us/articles/204017423-India-Features-Restrictions (I am currently drafting up a small addition to this page instructing users sending SMS to India, to use these two fields. So linking the two docs together).

# New 

* Added two new fields to `https://rest.nexmo.com/sms/:format` called `entity-id` and `content-id` which are both strings with no defined length. Discussed this with the API team implementing this feature, and there's also no validation. The fields are simply forwarded on if they're provided.

# Checklist

- [x] version number incremented (in the `info` section of the spec)
