### PR TITLE
Tidy/Restructure Account API description

### DIFF
--- a/definitions/account.yml
+++ b/definitions/account.yml
@@ -110,7 +110,7 @@ paths:
       operationId: changeAccountSettings
       summary: Change Account Settings
       description: >-
-        Update the default callback URLs (where the webhooks are sent to) associated with your account:
+        Update the default webhook URLs associated with your account:
           * Callback URL for incoming SMS messages
           * Callback URL for delivery receipts
 
@@ -461,12 +461,12 @@ components:
         mo-callback-url:
           type: string
           format: url
-          description: The current or updated inbound message URI
+          description: The current or updated inbound message webhook URI
           example: https://example.com/webhooks/inbound-sms
         dr-callback-url:
           type: string
           format: url
-          description: The current or updated delivery receipt URI
+          description: The current or updated delivery receipt webhook URI
           example: https://example.com/webhooks/delivery-receipt
         max-outbound-request:
           type: integer
@@ -595,8 +595,9 @@ components:
       properties:
         moCallBackUrl:
           description: >-
-            The URL where Vonage will send a webhook when an SMS is received
-            to a Vonage number that does not have SMS handling configured.
+            The default webhook URL for inbound SMS. If an SMS is received at a Vonage number 
+            that does not have its own inbound SMS webhook configured, Vonage makes a request
+            here.
 
             Send an empty string to unset this value.
           type: string
@@ -604,8 +605,8 @@ components:
           example: https://example.com/webhooks/inbound-sms
         drCallBackUrl:
           description: >-
-            The URL where Vonage will send a webhook when an delivery
-            receipt is received without a specific callback URL configured.
+            The webhook URL that Vonage makes a request to when a delivery receipt is available 
+            for an SMS sent by one of your Vonage numbers.
 
             Send an empty string to unset this value.
           type: string

--- a/definitions/account.yml
+++ b/definitions/account.yml
@@ -1,7 +1,7 @@
 openapi: "3.0.2"
 info:
   title: "Account API"
-  version: "1.0.2"
+  version: "1.0.3"
   description: >-
     Enables users to manage their Vonage API Account by programmable means. More information is available here: <https://developer.nexmo.com/account/overview>.
   contact:
@@ -77,14 +77,8 @@ paths:
         content:
           application/x-www-form-urlencoded:
             schema:
-              type: object
-              required:
-                - trx
-              properties:
-                trx:
-                  type: string
-                  description: The transaction reference of the transaction when balance was added and auto-reload was enabled on your account.
-                  example: 8ef2447e69604f642ae59363aa5f781b
+              $ref: "#/components/schemas/topupRequest"
+
       responses:
         "200":
           description: Success
@@ -132,26 +126,7 @@ paths:
         content:
           application/x-www-form-urlencoded:
             schema:
-              type: object
-              properties:
-                moCallBackUrl:
-                  description: >-
-                    The URL where Vonage will send a webhook when an SMS is received
-                    to a Vonage number that does not have SMS handling configured.
-
-                    Send an empty string to unset this value.
-                  type: string
-                  format: url
-                  example: https://example.com/webhooks/inbound-sms
-                drCallBackUrl:
-                  description: >-
-                    The URL where Vonage will send a webhook when an delivery
-                    receipt is received without a specific callback URL configured.
-
-                    Send an empty string to unset this value.
-                  type: string
-                  format: url
-                  example: https://example.com/webhooks/delivery-receipt
+              $ref: "#/components/schemas/accountSettingsRequest"
       responses:
         "200":
           description: OK. Settings were updated if supplied, the details of the current settings are included in the response.
@@ -253,22 +228,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - secret
-              properties:
-                secret:
-                  description: |
-                    The new secret must follow these rules:
-
-                    * minimum 8 characters
-                    * maximum 25 characters
-                    * minimum 1 lower case character
-                    * minimum 1 upper case character
-                    * minimum 1 digit
-
-                  type: string
-                  example: "example-4PI-secret"
+              $ref: "#/components/schemas/createSecretRequest"
       responses:
         "201":
           description: Secret created
@@ -629,6 +589,56 @@ components:
           type: string
           description: Internal Trace ID
           example: bf0ca0bf927b3b52e3cb03217e1a1ddf
+
+    accountSettingsRequest:
+      type: object
+      properties:
+        moCallBackUrl:
+          description: >-
+            The URL where Vonage will send a webhook when an SMS is received
+            to a Vonage number that does not have SMS handling configured.
+
+            Send an empty string to unset this value.
+          type: string
+          format: url
+          example: https://example.com/webhooks/inbound-sms
+        drCallBackUrl:
+          description: >-
+            The URL where Vonage will send a webhook when an delivery
+            receipt is received without a specific callback URL configured.
+
+            Send an empty string to unset this value.
+          type: string
+          format: url
+          example: https://example.com/webhooks/delivery-receipt
+
+    createSecretRequest:
+      type: object
+      required:
+        - secret
+      properties:
+        secret:
+          description: |
+            The new secret must follow these rules:
+
+            * minimum 8 characters
+            * maximum 25 characters
+            * minimum 1 lower case character
+            * minimum 1 upper case character
+            * minimum 1 digit
+
+          type: string
+          example: "example-4PI-secret"
+    topupRequest:
+      type: object
+      required:
+        - trx
+      properties:
+        trx:
+          type: string
+          description: The transaction reference of the transaction when balance was added and auto-reload was enabled on your account.
+          example: 8ef2447e69604f642ae59363aa5f781b
+
 
   responses:
     BadCredentialsError:


### PR DESCRIPTION
# Description

Restructure the Account API to have named request bodies along the same lines as our other APIs (and to please the tool I'm using)

# Fixes

* Improves structure of Account API description

# Checklist

- [x] version number incremented (in the `info` section of the spec)
