### PR TITLE
DEVX-4911 Can specify list of UUIDs

### DIFF
--- a/definitions/reports.yml
+++ b/definitions/reports.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: 2.1.13
+  version: 2.1.14
   title: Reports API
   description: |
     The [Reports API](/reports/overview) enables you to request a report of activity for your Vonage account.

--- a/definitions/reports.yml
+++ b/definitions/reports.yml
@@ -66,7 +66,7 @@ paths:
           example: inbound
         - name: id
           description: |
-            The UUID of the message or call to be searched for.
+            The UUID of the message or call to be searched for. You can specify a comma-separated list of UUIDs. If UUIDs are not found they are listed in the response in the `ids_not_found` field.
 
             If you specify `id`, you must not specify `status`, `date_start` or `date_end`.
           in: query

--- a/definitions/reports.yml
+++ b/definitions/reports.yml
@@ -841,6 +841,8 @@ components:
           $ref: "#/components/schemas/currency"
         account_id:
           $ref: "#/components/schemas/account_id"
+        ids_not_found:
+          $ref: "#/components/schemas/ids_not_found"
  
     # request fields
     product:
@@ -970,6 +972,10 @@ components:
       type: string
       description: The account ID (API key) you wish to search for. This can differ from the API key in the authorization header because some accounts can request reports for other accounts, e.g. a primary account owner wants to create a report for one of its subaccounts.
       example: "abcdef01"
+    ids_not_found:
+      type: string
+      description: If you request multiple records using a comma-separated list of UUIDs, then the UUIDs of any records not found are listed in this field.
+      example: "7b10a0c2-1a05-11eb-bad9-38f9d331649,7b1091b8-1a05-11eb-bad9-38f9d331493"
     include_subaccounts:
       type: boolean
       description: Whether to include subaccounts or not.


### PR DESCRIPTION
# Fixes

* You can now specify a comma-separated list of UUIDs to synchronously retrieve records for.

# Checklist

- [x] version number incremented (in the `info` section of the spec)
