### PR TITLE
Fixed a typo in the intial carrier NI info

### DIFF
--- a/definitions/number-insight.yml
+++ b/definitions/number-insight.yml
@@ -965,7 +965,7 @@ components:
     niInitialCarrierProperties:
       type: object
       x-nexmo-developer-collection-description-shown: true
-      description: "Information about the network `number` is currently connected to."
+      description: "Information about the network `number` was initially connected to."
       properties:
         network_code:
           type: string

--- a/definitions/number-insight.yml
+++ b/definitions/number-insight.yml
@@ -4,7 +4,7 @@ servers:
   - url: "https://api.nexmo.com/ni"
 info:
   title: Number Insight API
-  version: 1.0.9
+  version: 1.0.10
   description: >-
     The Number Insight API delivers real-time intelligence about the validity, reachability and roaming status of a phone number and tells you how to format the number correctly in your application. There are three levels of Number Insight API available: [Basic, Standard and Advanced](https://developer.nexmo.com/number-insight/overview#basic-standard-and-advanced-apis). The advanced API is available asynchronously as well as synchronously.
   contact:


### PR DESCRIPTION
# Description

<!--

The following will be used in our release notes and public changelog. Communicate well!

Example:

# New 

* Added new `/foobar/sync` endpoint to toggle widget status
* The `GET /v1/calls` endpoint now supports a `to` query parameter to filter calls to a single number

# Fixes

* Add HTTP 401 and 403 error code documentation to the `/v1/calls` endpoint
-->

# Fixes

* Initial carrier for NI is now described as the carrier a number was initially connected to, versus the number it is currently connected to.

# Checklist

- [ ] version number incremented (in the `info` section of the spec)
