### PR TITLE
Update GH actions to use `main` branch.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create Review App
-        uses: nexmo/github-actions/heroku-review-app@master
+        uses: nexmo/github-actions/heroku-review-app@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEROKU_PIPELINE_ID: ${{ secrets.HEROKU_PIPELINE_ID }}

--- a/.github/workflows/push-openapi-release.yml
+++ b/.github/workflows/push-openapi-release.yml
@@ -2,7 +2,7 @@ name: OpenAPI Release
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   releaseOAS:
     name: Release OAS
@@ -10,6 +10,6 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Release OAS
-      uses: nexmo/github-actions/openapi-release@master
+      uses: nexmo/github-actions/openapi-release@main
       env:
         GH_ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Add Changelog
-      uses: nexmo/github-actions/nexmo-changelog@master
+      uses: nexmo/github-actions/nexmo-changelog@main
       env:
         CHANGELOG_AUTH_TOKEN: ${{ secrets.CHANGELOG_AUTH_TOKEN }}
         CHANGELOG_CATEGORY: API


### PR DESCRIPTION
# Description

# Fixes

Make Github Actions  use `main` branch instead of `master`

# Checklist

- [ ] version number incremented (in the `info` section of the spec)
