### PR TITLE
Update sms.yml

### DIFF
--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -138,7 +138,7 @@ components:
           example: false
           default: true
         callback:
-          description: "**Advanced**: The webhook endpoint the delivery receipt for this sms is sent to. This parameter overrides the webhook endpoint you set in Dashboard."
+          description: "**Advanced**: The webhook endpoint the delivery receipt for this sms is sent to. This parameter overrides the webhook endpoint you set in Dashboard. Max 100 characters."
           type: string
           example: "https://example.com/sms-dlr"
         message-class:
@@ -194,7 +194,7 @@ components:
           type: string
           example: "300000"
         client-ref:
-          description: "**Advanced**: You can optionally include your own reference of up to 40 characters."
+          description: "**Advanced**: You can optionally include your own reference of up to 100 characters."
           type: string
           example: my-personal-reference
         account-ref:

--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: 1.0.10
+  version: 1.0.11
   title: SMS API
   description: With the SMS API you can send SMS from your account and lookup messages both messages that you've sent as well as messages sent to your virtual numbers. Numbers are specified in E.164 format. More SMS API documentation is at <https://developer.nexmo.com/messaging/sms/overview>
   contact:


### PR DESCRIPTION
Updated client-ref that it supports 100 characters , added comment that callback has 100 char limit too

# Description

<!--

The following will be used in our release notes and public changelog. Communicate well!

Example:

# New 

* Added new `/foobar/sync` endpoint to toggle widget status
* The `GET /v1/calls` endpoint now supports a `to` query parameter to filter calls to a single number

# Fixes

* Add HTTP 401 and 403 error code documentation to the `/v1/calls` endpoint
-->

# Checklist

- [ ] version number incremented (in the `info` section of the spec)
