### PR TITLE
VAPI Random From Number

### DIFF
--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: 1.3.6
+  version: 1.3.7
   title: Voice API
   description:
     The Voice API lets you create outbound calls, control in-progress calls

--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -518,7 +518,6 @@ components:
       type: object
       required:
         - to
-        - from
       properties:
         to:
           type: array
@@ -530,6 +529,11 @@ components:
               - "$ref": "#/components/schemas/EndpointVBCExtension"
         from:
           "$ref": "#/components/schemas/EndpointPhoneFrom"
+          
+        random_from_number:
+          description: Set to `true` to use random phone number as `from`. The number will be selected from the list of the numbers assigned to the current application.
+          type: boolean
+          default: false
 
         event_url:
           description: |


### PR DESCRIPTION
# Description
New VAPI feature added - the ability to use random `from` number, selected from one of the phone numbers assigned to the application.

# New 

* Add new `random_from_number` parameter to POST /v1/calls request;
* `from` in POST /v1/calls request is not mandatory now.

# Checklist

- [x] version number incremented (in the `info` section of the spec)
