### PR TITLE
Added nullable to fields that now return null

### DIFF
--- a/definitions/number-insight.yml
+++ b/definitions/number-insight.yml
@@ -4,7 +4,7 @@ servers:
   - url: "https://api.nexmo.com/ni"
 info:
   title: Number Insight API
-  version: 1.0.10
+  version: 1.1.0
   description: >-
     The Number Insight API delivers real-time intelligence about the validity, reachability and roaming status of a phone number and tells you how to format the number correctly in your application. There are three levels of Number Insight API available: [Basic, Standard and Advanced](https://developer.nexmo.com/number-insight/overview#basic-standard-and-advanced-apis). The advanced API is available asynchronously as well as synchronously.
   contact:
@@ -380,10 +380,13 @@ components:
           description: "Your account balance in EUR after this request."
           example: "1.23456789"
         current_carrier:
-          $ref: "#/components/schemas/niCurrentCarrierProperties"
+          nullable: true
+          allOf:
+            - $ref: "#/components/schemas/niCurrentCarrierProperties"
         original_carrier:
           $ref: "#/components/schemas/niInitialCarrierProperties"
         ported:
+          nullable: true
           description: "If the user has changed carrier for number. The assumed status means that the information supplier has replied to the request but has not said explicitly that the number is ported"
           properties:
             ported_message:
@@ -399,6 +402,7 @@ components:
               xml:
                 x-text: true
         roaming:
+          nullable: true
           type: object
           description: "Information about the roaming status for number. This is applicable to mobile numbers only."
           x-nexmo-developer-collection-description-shown: true
@@ -665,6 +669,7 @@ components:
             - inferred_not_valid
           example: "valid"
         ip_warnings:
+          nullable: true
           type: string
           description: "This property is deprecated and can safely be ignored."
           example: "unknown"
@@ -728,7 +733,9 @@ components:
               description: "Your account balance in EUR after this request."
               example: "1.23456789"
             current_carrier:
-              $ref: "#/components/schemas/niCurrentCarrierProperties"
+              nullable: true
+              allOf:
+                - $ref: "#/components/schemas/niCurrentCarrierProperties"
             original_carrier:
               $ref: "#/components/schemas/niInitialCarrierProperties"
             ported:
@@ -930,12 +937,14 @@ components:
       description: "Information about the network `number` is currently connected to."
       properties:
         network_code:
+          nullable: true
           type: string
-          description: "The [https://en.wikipedia.org/wiki/Mobile_country_code](https://en.wikipedia.org/wiki/Mobile_country_code) for the carrier`number` is associated with. Unreal numbers are marked as`unknown` and the request is rejected altogether if the number is impossible according to the [E.164](https://en.wikipedia.org/wiki/E.164) guidelines."
+          description: "The [https://en.wikipedia.org/wiki/Mobile_country_code](https://en.wikipedia.org/wiki/Mobile_country_code) for the carrier`number` is associated with. Unreal numbers are marked as`null` and the request is rejected altogether if the number is impossible according to the [E.164](https://en.wikipedia.org/wiki/E.164) guidelines."
           xml:
             attribute: true
           example: "12345"
         name:
+          nullable: true
           type: string
           description: "The full name of the carrier that `number` is associated with."
           xml:
@@ -948,6 +957,7 @@ components:
             attribute: true
           example: "GB"
         network_type:
+          nullable: true
           type: string
           description: "The type of network that `number` is associated with."
           enum:
@@ -968,24 +978,28 @@ components:
       description: "Information about the network `number` was initially connected to."
       properties:
         network_code:
+          nullable: true
           type: string
-          description: "The [https://en.wikipedia.org/wiki/Mobile_country_code](https://en.wikipedia.org/wiki/Mobile_country_code) for the carrier`number` is associated with. Unreal numbers are marked as`unknown` and the request is rejected altogether if the number is impossible according to the [E.164](https://en.wikipedia.org/wiki/E.164) guidelines."
+          description: "The [https://en.wikipedia.org/wiki/Mobile_country_code](https://en.wikipedia.org/wiki/Mobile_country_code) for the carrier`number` is associated with. Unreal numbers are marked as`null` and the request is rejected altogether if the number is impossible according to the [E.164](https://en.wikipedia.org/wiki/E.164) guidelines."
           xml:
             attribute: true
           example: "12345"
         name:
+          nullable: true
           type: string
           description: "The full name of the carrier that `number` is associated with."
           xml:
             attribute: true
           example: "Acme Inc"
         country:
+          nullable: true
           type: string
           description: "The country that `number` is associated with. This is in ISO 3166-1 alpha-2   format."
           xml:
             attribute: true
           example: "GB"
         network_type:
+          nullable: true
           type: string
           description: "The type of network that `number` is associated with."
           enum:

--- a/definitions/number-insight.yml
+++ b/definitions/number-insight.yml
@@ -553,6 +553,7 @@ components:
         original_carrier:
           $ref: "#/components/schemas/niInitialCarrierProperties"
         ported:
+          nullable: true
           description: "If the user has changed carrier for `number`. The assumed status means that the information supplier has replied to the request but has not said explicitly that the number is ported."
           properties:
             ported_message:
@@ -647,6 +648,7 @@ components:
               xml:
                 x-text: true # see https://github.com/OAI/OpenAPI-Specification/issues/630
         reachable:
+          nullable: true
           type: string
           description: "Can you call `number` now. This is applicable to mobile numbers only."
           enum:
@@ -739,6 +741,7 @@ components:
             original_carrier:
               $ref: "#/components/schemas/niInitialCarrierProperties"
             ported:
+              nullable: true
               type: string
               description: "If the user has changed carrier for `number`. The assumed status means that the information supplier has replied to the request but has not said explicitly that the number is ported."
               enum:
@@ -831,6 +834,7 @@ components:
         original_carrier:
           $ref: "#/components/schemas/niInitialCarrierProperties"
         ported:
+          nullable: true
           type: string
           description: "If the user has changed carrier for `number`. The assumed status means that the information supplier has replied to the request but has not said explicitly that the number is ported."
           enum:
@@ -875,6 +879,7 @@ components:
           example: "valid"
         reachable:
           type: string
+          nullable: true
           description: "Can you call `number` now. This is applicable to mobile numbers only."
           enum:
             - unknown
@@ -933,6 +938,7 @@ components:
 
     niCurrentCarrierProperties:
       type: object
+      nullable: true
       x-nexmo-developer-collection-description-shown: true
       description: "Information about the network `number` is currently connected to."
       properties:
@@ -951,6 +957,7 @@ components:
             attribute: true
           example: "Acme Inc"
         country:
+          nullable: true
           type: string
           description: "The country that `number` is associated with. This is in ISO 3166-1 alpha-2   format."
           xml:
@@ -1015,6 +1022,7 @@ components:
           example: "mobile"
 
     niRoaming:
+      nullable: true
       type: object
       description: "Information about the roaming status for `number`. This is applicable to mobile numbers only."
       properties:


### PR DESCRIPTION
This change is dependent on a OAS Renderer fix which is currently being worked on. 

# Description

* Converts appropriate values to Nullable

# Checklist

- [x] version number incremented (in the `info` section of the spec)
