### PR TITLE
[SubAccount API] Add maxLength to Account name

### DIFF
--- a/definitions/subaccounts.yml
+++ b/definitions/subaccounts.yml
@@ -771,6 +771,7 @@ components:
       properties:
         name:
           type: string
+          maxLength: 80
           example: "Subaccount department A"
         secret:
           type: string

--- a/definitions/subaccounts.yml
+++ b/definitions/subaccounts.yml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers:
   - url: "https://api.nexmo.com/accounts"
 info:
-  version: 1.0.7
+  version: 1.0.8
   title: Subaccounts API
   description: >-
     The Subaccounts API enables you to create subaccounts under your primary account. Subaccounts facilitate differential product configuration, reporting, and billing. The Subaccounts API is released initially with restricted availability. You can read more about the API in the [Subaccounts documentation](/account/subaccounts/overview).


### PR DESCRIPTION
# Description

The limit for account names has changed from 24 to 80 characters. The original limit was never documented here.

# New 

The POST `/{api_key}/subaccounts` endpoint now supports a `name` property that is up to 80 characters long

# Checklist

- [x] version number incremented (in the `info` section of the spec)
