### PR TITLE
Removed HTML from descriptions

### DIFF
--- a/definitions/conversation.yml
+++ b/definitions/conversation.yml
@@ -17,13 +17,8 @@ paths:
       tags:
         - conversation
       summary: List conversations
-      description: >
-        <div class="Vlt-callout Vlt-callout--warning">
-        <i></i>
-        <div class="Vlt-callout__content">
-        <p><strong>This API endpoint is deprecated. Please use <a href="/api/conversation.v2#get-conversations">/v0.2/conversations</a></strong>.<br />This endpoint will return a maximum of 100 items.</p>
-        </div>
-        </div>
+      description: This endpoint is **DEPRECATED**. Please use [/v0.2/conversations](/api/conversation.v2#get-conversations).
+
 
         List all conversations associated with your application. 
         This endpoint required an admin JWT. To find all conversations for
@@ -204,13 +199,7 @@ paths:
       - $ref: "#/components/parameters/conversation_id"
     get:
       operationId: getEvents
-      description: >
-        <div class="Vlt-callout Vlt-callout--warning">
-        <i></i>
-        <div class="Vlt-callout__content">
-        <p><strong>This API endpoint is deprecated. Please use <a href="/api/conversation.v2#get-events">/v0.2/events</a></strong><br />This endpoint will return a maximum of 100 items.</p>
-        </div>
-        </div>
+      description: This endpoint is **DEPRECATED**. Please use [/v0.2/events](/api/conversation.v2#get-events).
       deprecated: true
       tags:
         - event
@@ -291,13 +280,7 @@ paths:
       - $ref: "#/components/parameters/conversation_id"
     get:
       operationId: getMembers
-      description: >
-        <div class="Vlt-callout Vlt-callout--warning">
-        <i></i>
-        <div class="Vlt-callout__content">
-        <p><strong>This API endpoint is deprecated. Please use <a href="/api/conversation.v2#get-members">/v0.2/members</a></strong><br />This endpoint will return a maximum of 100 items.</p>
-        </div>
-        </div>
+      description: This endpoint is **DEPRECATED**. Please use [/v0.2/members](/api/conversation.v2#get-members).
       deprecated: true
       tags:
         - member
@@ -432,13 +415,7 @@ paths:
   /users:
     get:
       operationId: getUsers
-      description: >
-        <div class="Vlt-callout Vlt-callout--warning">
-        <i></i>
-        <div class="Vlt-callout__content">
-        <strong>This API endpoint is deprecated. Please use <a href="/api/conversation.v2#get-users">/v0.2/users</a><br />This endpoint will return a maximum of 100 items.</strong>
-        </div>
-        </div>
+      description: This endpoint is **DEPRECATED**. Please use [/v0.2/users](/api/conversation.v2#get-users).
       deprecated: true
       tags:
         - user


### PR DESCRIPTION
# Description
#Fixes

* Removed and replaced HTML deprecation warnings that were in the descriptions of some `/v0.1/conversation` endpoints.

# Checklist

- [ ] version number incremented (in the `info` section of the spec)
