### PR TITLE
Changes dev.nexmo to dev.vonage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@
 *.iml
 *.ipr
 *.iws
+.DS_Store
 
 

--- a/definitions/10dlc.yml
+++ b/definitions/10dlc.yml
@@ -1,11 +1,11 @@
 openapi: 3.0.3
 
 info:
-  version: 1.0.0
+  version: 1.0.1
   title: 10DLC Brand and Campaign Provisioning
   contact:
     name: Vonage
-    url: https://developer.nexmo.com
+    url: https://developer.vonage.com
     email: devrel@vonage.com
   description: APIs relating to 10DLC brand and campaign management
 
@@ -657,7 +657,7 @@ components:
                     example: There were some issues with your submission
                   type:
                     description: Link to error / remediation options
-                    example: "https://developer.nexmo.com/api-errors/10dlc#error-type"
+                    example: "https://developer.vonage.com/api-errors/10dlc#error-type"
                   detail:
                     description: Additional information about the error
                     example: There were some errors submitting your brand, and a more detailed message would appear here
@@ -677,7 +677,7 @@ components:
                     example: An error occurred with this brand while communicating with a third party
                   type:
                     description: Link to error / remediation options
-                    example: "https://developer.nexmo.com/api-errors/10dlc#error-brand-conflict"
+                    example: "https://developer.vonage.com/api-errors/10dlc#error-brand-conflict"
                   detail:
                     description: Additional information about the error
                     example: An unknown error occurred while processing this brand with the carrier system. Please contact support or try again later.
@@ -697,7 +697,7 @@ components:
                     example: This brand has not been qualified for the given use case
                   type:
                     description: Link to error / remediation options
-                    example: "https://developer.nexmo.com/api-errors/10dlc#error-brand-not-qualified"
+                    example: "https://developer.vonage.com/api-errors/10dlc#error-brand-not-qualified"
                   detail:
                     description: Additional information about the error
                     example: A campaign use case must be checked before a campaign can be created. Please verify the brand use case before submitting this campaign.
@@ -717,7 +717,7 @@ components:
                     example: There were some issues with the submitted data
                   type:
                     description: Link to error / remediation options
-                    example: "https://developer.nexmo.com/api-errors/10dlc#invalid-brand-data"
+                    example: "https://developer.vonage.com/api-errors/10dlc#invalid-brand-data"
                   detail:
                     description: Additional information about the error
                     example: There were some errors submitting your brand, please correct the requested fields
@@ -755,7 +755,7 @@ components:
                     example: There were some issues with the submitted data
                   type:
                     description: Link to error / remediation options
-                    example: "https://developer.nexmo.com/api-errors/10dlc#invalid-campaign-data"
+                    example: "https://developer.vonage.com/api-errors/10dlc#invalid-campaign-data"
                   detail:
                     description: Additional information about the error
                     example: There were some errors submitting your campaign, please correct the requested fields
@@ -793,7 +793,7 @@ components:
                     example: Number Already Linked
                   type:
                     description: Link to error / remediation options
-                    example: "https://developer.nexmo.com/api-errors/10dlc#number-already-linked"
+                    example: "https://developer.vonage.com/api-errors/10dlc#number-already-linked"
                   detail:
                     description: Additional information about the error
                     example: The number requested has already been linked to another campaign
@@ -813,7 +813,7 @@ components:
                     example: There were some issues with the submitted data
                   type:
                     description: Link to error / remediation options
-                    example: "https://developer.nexmo.com/api-errors/10dlc#invalid-number-data"
+                    example: "https://developer.vonage.com/api-errors/10dlc#invalid-number-data"
                   detail:
                     description: Additional information about the error
                     example: There were some errors submitting your campaign, please correct the requested fields
@@ -847,7 +847,7 @@ components:
                     example: There were some issues with the submitted data
                   type:
                     description: Link to error / remediation options
-                    example: "https://developer.nexmo.com/api-errors/10dlc#invalid-usecase-data"
+                    example: "https://developer.vonage.com/api-errors/10dlc#invalid-usecase-data"
                   detail:
                     description: Additional information about the error
                     example: There were some errors qualifying the use case for your brand, please correct the requested fields
@@ -885,7 +885,7 @@ components:
                     example: Unable to parse incoming request
                   type:
                     description: Link to error / remediation options
-                    example: "https://developer.nexmo.com/api-errors/10dlc#invalid-json"
+                    example: "https://developer.vonage.com/api-errors/10dlc#invalid-json"
                   detail:
                     description: Additional information about the error
                     example: invalid character 'f' after object key:value pair
@@ -905,7 +905,7 @@ components:
                     example: The requested use case is denied for this brand
                   type:
                     description: Link to error / remediation options
-                    example: "https://developer.nexmo.com/api-errors/10dlc#use-case-denied"
+                    example: "https://developer.vonage.com/api-errors/10dlc#use-case-denied"
                   detail:
                     description: Additional information about the error
                     example: The requested use case has been denied for this brand. Your brand may require additional third party vetting.
@@ -925,7 +925,7 @@ components:
                     example: An error occurred while requesting third party vetting
                   type:
                     description: Link to error / remediation options
-                    example: "https://developer.nexmo.com/api-errors/10dlc#error-vetting-conflict"
+                    example: "https://developer.vonage.com/api-errors/10dlc#error-vetting-conflict"
                   detail:
                     description: Additional information about the error
                     example: An unknown error occurred while requesting vetting with the carrier system. Please contact support or try again later.
@@ -945,7 +945,7 @@ components:
                     example: There were some issues with the submitted data
                   type:
                     description: Link to error / remediation options
-                    example: "https://developer.nexmo.com/api-errors/10dlc#invalid-vetting-data"
+                    example: "https://developer.vonage.com/api-errors/10dlc#invalid-vetting-data"
                   detail:
                     description: Additional information about the error
                     example: There were some errors submitting your vetting request, please correct the requested fields
@@ -2219,7 +2219,7 @@ components:
               example: There were errors removing numbers from the pool
             type:
               description: Link to error / remediation options
-              example: "https://developer.nexmo.com/api-errors/10dlc#number-deletion-failure"
+              example: "https://developer.vonage.com/api-errors/10dlc#number-deletion-failure"
             detail:
               description: Additional information about the error
               example: We were unable to remove any of the numbers from the campaign.
@@ -2233,7 +2233,7 @@ components:
                     example: Number not found
                   type:
                     description: Link to error / remediation options
-                    example: "https://developer.nexmo.com/api-errors/10dlc#missing-number"
+                    example: "https://developer.vonage.com/api-errors/10dlc#missing-number"
                   detail:
                     description: Additional information about the error
                     example: One or more numbers being deleted are not available in the campaign

--- a/definitions/account.yml
+++ b/definitions/account.yml
@@ -1,12 +1,12 @@
 openapi: "3.0.2"
 info:
   title: "Account API"
-  version: "1.0.3"
+  version: "1.0.4"
   description: >-
-    Enables users to manage their Vonage API Account by programmable means. More information is available here: <https://developer.nexmo.com/account/overview>.
+    Enables users to manage their Vonage API Account by programmable means. More information is available here: <https://developer.vonage.com/account/overview>.
   contact:
     name: Vonage.com
-    url: "https://developer.nexmo.com"
+    url: "https://developer.vonage.com"
 servers:
   - url: "https://api.nexmo.com"
 paths:
@@ -255,7 +255,7 @@ paths:
                   type:
                     type: string
                     description: URL for further information
-                    example: https://developer.nexmo.com/api-errors/account/secret-management#validation
+                    example: https://developer.vonage.com/api-errors/account/secret-management#validation
                   title:
                     type: string
                     description: Description of the error
@@ -353,7 +353,7 @@ paths:
                   type:
                     type: string
                     description: URL for further information
-                    example: https://developer.nexmo.com/api-errors/account/secret-management#delete-last-secret
+                    example: https://developer.vonage.com/api-errors/account/secret-management#delete-last-secret
                   title:
                     type: string
                     description: Description of the error
@@ -392,7 +392,7 @@ components:
       type: http
       scheme: basic
       description: >-
-        Provide an `Authorization` header, with a value of "Basic" followed by the result of base64-encoding your Vonage API key and secret separated by a colon. You can find your API key and secret on the [dashboard](https://dashboard.nexmo.com) and more information is available [on the developer portal](https://developer.nexmo.com/concepts/guides/authentication#header-based-api-key-and-secret-authentication).
+        Provide an `Authorization` header, with a value of "Basic" followed by the result of base64-encoding your Vonage API key and secret separated by a colon. You can find your API key and secret on the [dashboard](https://dashboard.nexmo.com) and more information is available [on the developer portal](https://developer.vonage.com/concepts/guides/authentication#header-based-api-key-and-secret-authentication).
 
         If your API key were aaa012 and your API secret were abc123456789 then your HTTP header would be: `Authorization: Basic YWFhMDEyOmFiYzEyMzQ1Njc4OQ==`
 
@@ -516,8 +516,8 @@ components:
         type:
           type: string
           description: URL for further information
-          # example: https://developer.nexmo.com/api-errors#invalid-id
-          example: https://developer.nexmo.com/api-errors#invalid-api-key
+          # example: https://developer.vonage.com/api-errors#invalid-id
+          example: https://developer.vonage.com/api-errors#invalid-api-key
         title:
           type: string
           description: Description of the error
@@ -576,7 +576,7 @@ components:
         type:
           type: string
           description: URL for further information
-          example: https://developer.nexmo.com/api-errors#invalid-id
+          example: https://developer.vonage.com/api-errors#invalid-id
         title:
           type: string
           description: Description of the error
@@ -651,7 +651,7 @@ components:
               type:
                 type: string
                 description: URL for further information
-                example: https://developer.nexmo.com/
+                example: https://developer.vonage.com/
               title:
                 type: string
                 description: Description of the error

--- a/definitions/application.v2.yml
+++ b/definitions/application.v2.yml
@@ -1,7 +1,7 @@
 ---
 openapi: "3.0.0"
 info:
-  version: 2.1.1
+  version: 2.1.2
   title: "Application API"
   description: |
     Vonage provides an Application API to allow management of your Vonage Applications.
@@ -9,7 +9,7 @@ info:
     This API is backwards compatible with version 1. Applications created using version 1 of the API can also be managed using version 2 (this version) of the API.
   contact:
     name: Vonage
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
     email: devrel@nexmo.com
 servers:
   - url: https://api.nexmo.com/v2/applications
@@ -47,7 +47,7 @@ paths:
                 properties:
                   type:
                     type: string
-                    example: "https://developer.nexmo.com/api-errors/application#list-validation"
+                    example: "https://developer.vonage.com/api-errors/application#list-validation"
                   title:
                     type: string
                     example: Bad Request
@@ -632,7 +632,7 @@ components:
             properties:
               type:
                 type: string
-                example: "https://developer.nexmo.com/api-errors/application#payload-validation"
+                example: "https://developer.vonage.com/api-errors/application#payload-validation"
               title:
                 type: string
                 example: Bad Request

--- a/definitions/application.yml
+++ b/definitions/application.yml
@@ -16,7 +16,7 @@ info:
   contact:
     name: Nexmo.com
     email: devrel@nexmo.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
     x-twitter: Nexmo
   termsOfService: "https://www.nexmo.com/terms-of-use"
   license:
@@ -28,7 +28,7 @@ info:
 servers:
   - url: "https://api.nexmo.com/v1/applications"
 externalDocs:
-  url: "https://developer.nexmo.com/api/developer/application"
+  url: "https://developer.vonage.com/api/developer/application"
   x-sha1: d8836c374e2a7504bd2cd59e05fcee440f67cb44
 paths:
   /:

--- a/definitions/audit.yml
+++ b/definitions/audit.yml
@@ -1,17 +1,17 @@
 openapi: "3.0.0"
 
 info:
-  version: 1.0.4
+  version: 1.0.5
   title: Audit API
   description: >
-    The Vonage Audit API allows you to view details of changes to your account. More information is available at <https://developer.nexmo.com/audit/overview>.
+    The Vonage Audit API allows you to view details of changes to your account. More information is available at <https://developer.vonage.com/audit/overview>.
 
     _Please note that the Audit API is currently in Beta_
   x-label: Beta
   contact:
     name: Vonage DevRel
     email: devrel@vonage.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
   termsOfService: "https://www.nexmo.com/terms-of-use"
   license:
     name: The MIT License (MIT)

--- a/definitions/conversation.v2.yml
+++ b/definitions/conversation.v2.yml
@@ -2,13 +2,13 @@ openapi: 3.0.0
 servers:
   - url: "https://api.nexmo.com/v0.2"
 info:
-  version: 1.0.1
+  version: 1.0.2
   title: Conversation API
   description: "The Conversation API enables you to build conversation features where communication can take place across multiple mediums including IP Messaging, PSTN Voice, SMS and WebRTC Audio and Video. The context of the conversations is maintained though each communication event taking place within a conversation, no matter the medium."
   contact:
     name: Vonage DevRel
     email: devrel@vonage.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
   x-label: Beta
 paths:
   "/conversations":

--- a/definitions/conversation.yml
+++ b/definitions/conversation.yml
@@ -2,13 +2,13 @@ openapi: 3.0.0
 servers:
   - url: "https://api.nexmo.com/v0.1"
 info:
-  version: 2.0.1
+  version: 2.0.2
   title: Conversation API
   description: "The Conversation API enables you to build conversation features where communication can take place across multiple mediums including IP Messaging, PSTN Voice, SMS and WebRTC Audio and Video. The context of the conversations is maintained though each communication event taking place within a conversation, no matter the medium."
   contact:
     name: Vonage DevRel
     email: devrel@vonage.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
   x-label: Beta
 paths:
   /conversations:

--- a/definitions/conversion.yml
+++ b/definitions/conversion.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
-  title: Nexmo Conversion API
-  version: 1.0.1
+  title: Conversion API
+  version: 1.0.2
   description: >-
     The Conversion API allows you to tell Nexmo about the reliability of your
     2FA communications. Sending conversion data back to us means that Nexmo can
@@ -19,7 +19,7 @@ info:
   contact:
     name: Nexmo.com
     email: devrel@nexmo.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
     x-twitter: Nexmo
   termsOfService: "https://www.nexmo.com/terms-of-use"
   license:
@@ -31,7 +31,7 @@ info:
 servers:
   - url: "https://api.nexmo.com/conversions"
 externalDocs:
-  url: "https://developer.nexmo.com/api/conversion"
+  url: "https://developer.vonage.com/api/conversion"
   x-sha1: 8ad8bc6b0c51af4ca458c13cfced6124783ab113
 security:
   - apiKey: []

--- a/definitions/developer/messages.yml
+++ b/definitions/developer/messages.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Message Search API
-  version: 1.0.6
+  version: 1.0.7
   description: >-
 
     <div class="Vlt-callout Vlt-callout--critical">
@@ -17,7 +17,7 @@ info:
   contact:
     name: Vonage.com
     email: devrel@vonage.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
     x-twitter: Vonage
   termsOfService: "https://www.nexmo.com/terms-of-use"
   license:

--- a/definitions/dispatch.yml
+++ b/definitions/dispatch.yml
@@ -1,12 +1,12 @@
 openapi: "3.0.0"
 info:
-  version: 0.3.3
+  version: 0.3.4
   title: Dispatch API
   description: "The Dispatch API enables the developer to specify a multiple message workflow. A workflow follows a template. The first one we are adding is the failover template. The failover template instructs the Messages API to first send a message to the specified channel. If that message fails immediately or if the condition_status is not reached within the given time period the next message is sent. The developer will also receive status webhooks from the messages resource for each delivery and read event. This API is currently in Beta."
   contact:
     name: Vonage DevRel
     email: devrel@vonage.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
   x-label: Beta
 servers:
   - url: https://api.nexmo.com/v0.1/dispatch

--- a/definitions/external-accounts.yml
+++ b/definitions/external-accounts.yml
@@ -1,13 +1,13 @@
 openapi: "3.0.0"
 info:
-  version: 0.1.5
+  version: 0.1.6
   title: External Accounts API
-  description: "The External Accounts API is used to manage accounts for Viber Service Messages, Facebook Messenger and Whatsapp for use in the [Messages](https://developer.nexmo.com/messages/overview) and [Dispatch](https://developer.nexmo.com/dispatch/overview) APIs."
+  description: "The External Accounts API is used to manage accounts for Viber Service Messages, Facebook Messenger and Whatsapp for use in the [Messages](https://developer.vonage.com/messages/overview) and [Dispatch](https://developer.vonage.com/dispatch/overview) APIs."
   x-label: Developer Preview
   contact:
     name: Vonage DevRel
     email: devrel@vonage.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
 servers:
   - url: https://api.nexmo.com/beta/chatapp-accounts
 
@@ -60,7 +60,7 @@ paths:
                     <li>There is just one application allowed per an account.</li>
                     <li>The application type must be type "messages".</li>
                     </ul>
-                    For more information see [Application API spec](https://developer.nexmo.com/api/application.v2)
+                    For more information see [Application API spec](https://developer.vonage.com/api/application.v2)
       responses:
         "201":
           description: Created.
@@ -486,7 +486,7 @@ paths:
                 application:
                   type: string
                   example: "applicationId"
-                  description: There is just one application allowed per an account. The application type must be type "messages". For more information please see [Application API Spec](https://developer.nexmo.com/api/application.v2)
+                  description: There is just one application allowed per an account. The application type must be type "messages". For more information please see [Application API Spec](https://developer.vonage.com/api/application.v2)
       responses:
         "200":
           description: OK.
@@ -780,8 +780,8 @@ tags:
   - name: "Account"
     description: An external-account used as the `from` field in the Messages API and Dispatch API
   - name: "Facebook Messenger"
-    description: "Managing your [Facebook Messenger](https://developer.nexmo.com/messages/concepts/facebook) account"
+    description: "Managing your [Facebook Messenger](https://developer.vonage.com/messages/concepts/facebook) account"
   - name: "Viber Service Message"
-    description: "Managing your [Viber Service Message](https://developer.nexmo.com/messages/concepts/viber) account"
+    description: "Managing your [Viber Service Message](https://developer.vonage.com/messages/concepts/viber) account"
   - name: "Whatsapp"
-    description: "Managing your [Whatsapp](https://developer.nexmo.com/messages/concepts/whatsapp) account"
+    description: "Managing your [Whatsapp](https://developer.vonage.com/messages/concepts/whatsapp) account"

--- a/definitions/media.yml
+++ b/definitions/media.yml
@@ -1,13 +1,13 @@
 openapi: "3.0.0"
 info:
-  version: 1.0.2
+  version: 1.0.3
   title: Media API
   description: The Media API can be used to query, download and delete media items such as audio files for use with other Nexmo APIs.
   x-label: "BETA"
   contact:
     name: Nexmo DevRel
     email: devrel@nexmo.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
 servers:
   - url: https://api.nexmo.com/v3/media
 paths:

--- a/definitions/messages-olympus.v0.yml
+++ b/definitions/messages-olympus.v0.yml
@@ -1,12 +1,12 @@
 openapi: "3.0.0"
 info:
-  version: 0.5.0
+  version: 0.5.1
   title: Messages API
   description: "The Messages API enables you to send messages to customers via their preferred channels (currently Facebook Messenger, WhatsApp, Viber, and SMS/MMS) using a single API. The Messages API is currently in Beta."
   contact:
     name: Vonage DevRel
     email: devrel@vonage.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
   x-label: Beta
 servers:
   - url: https://api.nexmo.com/v0.1/messages
@@ -1398,7 +1398,7 @@ components:
                   example: Hello From Vonage!
                   type: string
                   description: |
-                    Limited to 1000 characters. The Messages API automatically detects unicode characters when sending SMS and sends the message as a unicode SMS. For more information on how concatenation and encoding please visit: developer.nexmo.com/messaging/sms/guides/concatenation-and-encoding.
+                    Limited to 1000 characters. The Messages API automatically detects unicode characters when sending SMS and sends the message as a unicode SMS. For more information on how concatenation and encoding please visit: developer.vonage.com/messaging/sms/guides/concatenation-and-encoding.
     Sms:
       allOf:
         - type: object

--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -1,12 +1,12 @@
 openapi: "3.0.0"
 info:
-  version: 1.0.5
+  version: 1.0.6
   title: Messages API
   description: 'The Messages API consolidates and normalises exchanges across all messaging channels. It allows you to use a single API to interact with our various channels such as SMS, MMS, WhatsApp, Viber and Facebook Messenger'
   contact:
     name: Nexmo DevRel
     email: devrel@nexmo.com
-    url: 'https://developer.nexmo.com/'
+    url: 'https://developer.vonage.com/'
 servers:
   - url: https://api.nexmo.com/v1/messages
 paths:
@@ -34,7 +34,7 @@ paths:
                       - properties:
                           text:
                             description: |
-                                The text of message to send; limited to 1000 characters. The Messages API automatically detects unicode characters when sending SMS and sends the message as a unicode SMS. For more information on how concatenation and encoding please visit: [developer.nexmo.com/messaging/sms/guides/concatenation-and-encoding](https://developer.nexmo.com/messaging/sms/guides/concatenation-and-encoding).
+                                The text of message to send; limited to 1000 characters. The Messages API automatically detects unicode characters when sending SMS and sends the message as a unicode SMS. For more information on how concatenation and encoding please visit: [developer.vonage.com/messaging/sms/guides/concatenation-and-encoding](https://developer.vonage.com/messaging/sms/guides/concatenation-and-encoding).
                       - $ref: '#/components/schemas/channelOptionsSms'
                 - title: MMS
                   x-tab-id: MMS
@@ -725,7 +725,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/messages-olympus#1100
+          example: https://developer.vonage.com/api-errors/messages-olympus#1100
         title:
           type: string
           description: Generic error message
@@ -751,7 +751,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/messages-olympus#1110
+          example: https://developer.vonage.com/api-errors/messages-olympus#1110
         title:
           type: string
           description: Generic error message
@@ -790,7 +790,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/messages-olympus#1120
+          example: https://developer.vonage.com/api-errors/messages-olympus#1120
         title:
           type: string
           description: Generic error message
@@ -816,7 +816,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/messages-olympus#110
+          example: https://developer.vonage.com/api-errors/messages-olympus#110
         title:
           type: string
           description: Generic error message
@@ -842,7 +842,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/messages-olympus#1140
+          example: https://developer.vonage.com/api-errors/messages-olympus#1140
         title:
           type: string
           description: Generic error message
@@ -868,7 +868,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/messages-olympus#1150
+          example: https://developer.vonage.com/api-errors/messages-olympus#1150
         title:
           type: string
           description: Generic error message
@@ -907,7 +907,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/messages-olympus#1060
+          example: https://developer.vonage.com/api-errors/messages-olympus#1060
         title:
           type: string
           description: Generic error message
@@ -932,7 +932,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/#low-balance
+          example: https://developer.vonage.com/api-errors/#low-balance
         title:
           type: string
           description: Generic error message
@@ -957,7 +957,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/messages-olympus#1010
+          example: https://developer.vonage.com/api-errors/messages-olympus#1010
         title:
           type: string
           description: Generic error message
@@ -982,7 +982,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/messages-olympus#1000
+          example: https://developer.vonage.com/api-errors/messages-olympus#1000
         title:
           type: string
           description: Generic error message
@@ -1008,7 +1008,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors#invalid-json
+          example: https://developer.vonage.com/api-errors#invalid-json
         title:
           type: string
           description: Generic error message
@@ -1034,7 +1034,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/#unprovisioned
+          example: https://developer.vonage.com/api-errors/#unprovisioned
         title:
           type: string
           description: Generic error message
@@ -1060,7 +1060,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/#unathorized
+          example: https://developer.vonage.com/api-errors/#unathorized
         title:
           type: string
           description: Generic error message
@@ -1091,7 +1091,7 @@ components:
       type: string
       example: '447700900001'
       description: |
-           The phone number of the message **sender** in the [E.164](https://en.wikipedia.org/wiki/E.164) format. Don't use a leading + or 00 when entering a phone number, start with the country code, for example, 447700900000. For SMS in certain localities alpha-numeric sender id's will work as well, see [Global Messaging](https://developer.nexmo.com/messaging/sms/guides/country-specific-features#country-specific-features) for more details
+           The phone number of the message **sender** in the [E.164](https://en.wikipedia.org/wiki/E.164) format. Don't use a leading + or 00 when entering a phone number, start with the country code, for example, 447700900000. For SMS in certain localities alpha-numeric sender id's will work as well, see [Global Messaging](https://developer.vonage.com/messaging/sms/guides/country-specific-features#country-specific-features) for more details
 
     ToId:
       type: string
@@ -1249,15 +1249,15 @@ components:
               type: string
               format: url
               description: The type of error encountered, follow URL for more details
-              example: https://developer.nexmo.com/api-errors/messages-olympus#1000
+              example: https://developer.vonage.com/api-errors/messages-olympus#1000
             title:
               type: string
               example: 1000
-              description: The error code encountered when sending the message. See [our errors list](https://developer.nexmo.com/api-errors/messages-olympus) for a list of possible errors
+              description: The error code encountered when sending the message. See [our errors list](https://developer.vonage.com/api-errors/messages-olympus) for a list of possible errors
             detail:
               type: string
               example: 'Throttled - You have exceeded the submission capacity allowed on this account. Please wait and retry'
-              description: Text describing the error. See [our errors list](https://developer.nexmo.com/api-errors/messages-olympus) for a list of possible errors
+              description: Text describing the error. See [our errors list](https://developer.vonage.com/api-errors/messages-olympus) for a list of possible errors
             instance:
               type: string
               example: 'bf0ca0bf927b3b52e3cb03217e1a1ddf'

--- a/definitions/messaging-engagements.yml
+++ b/definitions/messaging-engagements.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 
 info:
-  version: 1.0.0
+  version: 1.0.1
   title: Identity Verification and Message Engagement Registration
   contact:
     name: Vonage

--- a/definitions/number-insight.yml
+++ b/definitions/number-insight.yml
@@ -4,19 +4,19 @@ servers:
   - url: "https://api.nexmo.com/ni"
 info:
   title: Number Insight API
-  version: 1.1.2
+  version: 1.1.3
   description: >-
-    The Number Insight API delivers real-time intelligence about the validity, reachability and roaming status of a phone number and tells you how to format the number correctly in your application. There are three levels of Number Insight API available: [Basic, Standard and Advanced](https://developer.nexmo.com/number-insight/overview#basic-standard-and-advanced-apis). The advanced API is available asynchronously as well as synchronously.
+    The Number Insight API delivers real-time intelligence about the validity, reachability and roaming status of a phone number and tells you how to format the number correctly in your application. There are three levels of Number Insight API available: [Basic, Standard and Advanced](https://developer.vonage.com/number-insight/overview#basic-standard-and-advanced-apis). The advanced API is available asynchronously as well as synchronously.
   contact:
     name: Vonage DevRel
     email: devrel@vonage.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
   termsOfService: "https://www.nexmo.com/terms-of-use"
   license:
     name: "The MIT License (MIT)"
     url: "https://opensource.org/licenses/MIT"
 externalDocs:
-  url: https://developer.nexmo.com/api/number-insight
+  url: https://developer.vonage.com/api/number-insight
   x-sha1: 081f6d985e2e4a75586da1654fde880a96885405
 security:
   - apiKey: []

--- a/definitions/numbers.yml
+++ b/definitions/numbers.yml
@@ -1,14 +1,14 @@
 openapi: 3.0.0
 info:
   title: Numbers API
-  version: 1.0.20
+  version: 1.0.21
   description: >-
     The Numbers API enables you to manage your existing numbers and buy new virtual numbers for
-    use with the Vonage APIs. Further information is here: <https://developer.nexmo.com/numbers/overview>
+    use with the Vonage APIs. Further information is here: <https://developer.vonage.com/numbers/overview>
   contact:
     name: Vonage DevRel
     email: devrel@vonage.com
-    url: "https://developer.nexmo.com"
+    url: "https://developer.vonage.com"
   termsOfService: "https://www.nexmo.com/terms-of-use"
   license:
     name: The MIT License (MIT)
@@ -18,7 +18,7 @@ servers:
   - url: "https://rest.nexmo.com"
 externalDocs:
   description: Numbers product documentation on the Vonage Developer Portal
-  url: "https://developer.nexmo.com/numbers/overview"
+  url: "https://developer.vonage.com/numbers/overview"
 security:
   - apiKey: []
     apiSecret: []

--- a/definitions/pricing.yml
+++ b/definitions/pricing.yml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers:
   - url: "https://rest.nexmo.com/account"
 info:
-  version: "0.0.3"
+  version: 0.0.4
   title: Pricing API
   description: >-
     The API to retrieve pricing information.
@@ -12,7 +12,7 @@ info:
   contact:
     name: Nexmo DevRel
     email: devrel@nexmo.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
 paths:
   /get-pricing/outbound/{type}:
     get:

--- a/definitions/redact.yml
+++ b/definitions/redact.yml
@@ -1,13 +1,13 @@
 ---
 openapi: "3.0.0"
 info:
-  version: 1.0.6
+  version: 1.0.7
   title: "Redact API"
   description: The [Redact API](/redact/overview) helps organisations meet their privacy compliance obligations. It provides controlled, on-demand redaction of private information from transactional records in the long-term storage. Note, Redact API does not have the capability to redact the short-lived server logs that are retained for a few weeks. For SMS customers that need immediate redaction, Vonage suggests using [Advanced Auto-redact](/redact/overview#auto-redact-vs-redact-api).
   contact:
     name: Vonage DevRel
     email: devrel@vonage.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
 servers:
   - url: https://api.nexmo.com/v1/redact
 paths:
@@ -80,7 +80,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/redact#invalid-product
+          example: https://developer.vonage.com/api-errors/redact#invalid-product
         title:
           type: string
           description: Generic error message
@@ -106,7 +106,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/redact#premature-redaction
+          example: https://developer.vonage.com/api-errors/redact#premature-redaction
         title:
           type: string
           description: Generic error message
@@ -132,7 +132,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors#unprovisioned
+          example: https://developer.vonage.com/api-errors#unprovisioned
         title:
           type: string
           description: Generic error message
@@ -173,7 +173,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors#invalid-json
+          example: https://developer.vonage.com/api-errors#invalid-json
         title:
           type: string
           description: Generic error message
@@ -198,7 +198,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors#invalid-id
+          example: https://developer.vonage.com/api-errors#invalid-id
         title:
           type: string
           description: Generic error message
@@ -223,7 +223,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/redact#rate-limit
+          example: https://developer.vonage.com/api-errors/redact#rate-limit
         title:
           type: string
           description: Generic error message

--- a/definitions/reports.yml
+++ b/definitions/reports.yml
@@ -13,7 +13,7 @@ info:
   contact:
     name: Vonage DevRel
     email: devrel@vonage.com
-    url: 'https://developer.nexmo.com/'
+    url: 'https://developer.vonage.com/'
   x-label: Beta
   termsOfService: 'https://www.nexmo.com/terms-of-use'
   license:
@@ -213,7 +213,7 @@ paths:
                     properties:
                       type:
                         type: string
-                        example: 'https://developer.nexmo.com/api-errors/reports#invalid-filter'
+                        example: 'https://developer.vonage.com/api-errors/reports#invalid-filter'
                       title:
                         type: string
                         example: 'Invalid filter'
@@ -724,7 +724,7 @@ components:
             properties:
               type:
                 type: string
-                example: 'https://developer.nexmo.com/api-errors#invalid-json'
+                example: 'https://developer.vonage.com/api-errors#invalid-json'
               title:
                 type: string
                 example: 'Malformed JSON'
@@ -742,7 +742,7 @@ components:
             properties:
               type:
                 type: string
-                example: 'https://developer.nexmo.com/api-errors/reports#invalid-request-parameters'
+                example: 'https://developer.vonage.com/api-errors/reports#invalid-request-parameters'
               title:
                 type: string
                 example: 'Invalid request parameter'
@@ -760,7 +760,7 @@ components:
             properties:
               type:
                 type: string
-                example: 'https://developer.nexmo.com/api-errors#unauthorized'
+                example: 'https://developer.vonage.com/api-errors#unauthorized'
               title:
                 type: string
                 example: 'Unauthorized'
@@ -778,7 +778,7 @@ components:
             properties:
               type:
                 type: string
-                example: 'https://developer.nexmo.com/api-errors#forbidden'
+                example: 'https://developer.vonage.com/api-errors#forbidden'
               title:
                 type: string
                 example: 'Forbidden'
@@ -796,7 +796,7 @@ components:
             properties:
               type:
                 type: string
-                example: 'https://developer.nexmo.com/api-errors#not-found'
+                example: 'https://developer.vonage.com/api-errors#not-found'
               title:
                 type: string
                 example: 'Invalid report ID'
@@ -814,7 +814,7 @@ components:
             properties:
               type:
                 type: string
-                example: 'https://developer.nexmo.com/api-errors/reports#invalid-abort-operation'
+                example: 'https://developer.vonage.com/api-errors/reports#invalid-abort-operation'
               title:
                 type: string
                 example: 'Invalid Abort Operation'
@@ -832,7 +832,7 @@ components:
             properties:
               type:
                 type: string
-                example: 'https://developer.nexmo.com/api-errors#not-found'
+                example: 'https://developer.vonage.com/api-errors#not-found'
               title:
                 type: string
                 example: 'Unprocessable entity'

--- a/definitions/sms.yml
+++ b/definitions/sms.yml
@@ -1,12 +1,12 @@
 openapi: "3.0.0"
 info:
-  version: 1.0.11
+  version: 1.0.13
   title: SMS API
-  description: With the SMS API you can send SMS from your account and lookup messages both messages that you've sent as well as messages sent to your virtual numbers. Numbers are specified in E.164 format. More SMS API documentation is at <https://developer.nexmo.com/messaging/sms/overview>
+  description: With the SMS API you can send SMS from your account and lookup messages both messages that you've sent as well as messages sent to your virtual numbers. Numbers are specified in E.164 format. More SMS API documentation is at <https://developer.vonage.com/messaging/sms/overview>
   contact:
     name: Vonage DevRel
     email: devrel@vonage.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
 servers:
   - url: https://rest.nexmo.com/sms
 paths:

--- a/definitions/subaccounts.yml
+++ b/definitions/subaccounts.yml
@@ -9,7 +9,7 @@ info:
   contact:
     name: Vonage DevRel
     email: devrel@vonage.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
 paths:
   /{api_key}/subaccounts:
     get:
@@ -409,7 +409,7 @@ components:
             properties:
               type:
                 type: string
-                example: "https://developer.nexmo.com/api-errors#unauthorized"
+                example: "https://developer.vonage.com/api-errors#unauthorized"
               title:
                 type: string
                 example: "Invalid credentials supplied"
@@ -440,7 +440,7 @@ components:
             properties:
               type:
                 type: string
-                example: "https://developer.nexmo.com/api-errors#invalid-api-key"
+                example: "https://developer.vonage.com/api-errors#invalid-api-key"
               title:
                 type: string
                 example: "Invalid API Key"
@@ -464,7 +464,7 @@ components:
             properties:
               type:
                 type: string
-                example: "https://developer.nexmo.com/api-errors/subaccounts#transfer-conflict"
+                example: "https://developer.vonage.com/api-errors/subaccounts#transfer-conflict"
               title:
                 type: string
                 example: "Transfer Conflict"
@@ -489,7 +489,7 @@ components:
             properties:
               type:
                 type: string
-                example: "https://developer.nexmo.com/api-errors/subaccounts#validation"
+                example: "https://developer.vonage.com/api-errors/subaccounts#validation"
               title:
                 type: string
                 example: "Bad Request"
@@ -524,7 +524,7 @@ components:
             properties:
               type:
                 type: string
-                example: "https://developer.nexmo.com/api-errors#internal-error"
+                example: "https://developer.vonage.com/api-errors#internal-error"
               title:
                 type: string
                 example: "Internal Error"
@@ -546,7 +546,7 @@ components:
       properties:
         type:
           type: string
-          example: "https://developer.nexmo.com/api-errors#unprovisioned"
+          example: "https://developer.vonage.com/api-errors#unprovisioned"
         title:
           type: string
           example: "Authorisation error"
@@ -567,7 +567,7 @@ components:
       properties:
         type:
           type: string
-          example: "https://developer.nexmo.com/api-errors/subaccounts#missing-number-transfer"
+          example: "https://developer.vonage.com/api-errors/subaccounts#missing-number-transfer"
         title:
           type: string
           example: "Invalid Number Transfer"
@@ -588,7 +588,7 @@ components:
       properties:
         type:
           type: string
-          example: "https://developer.nexmo.com/api-errors/subaccounts#invalid-number-transfer"
+          example: "https://developer.vonage.com/api-errors/subaccounts#invalid-number-transfer"
         title:
           type: string
           example: "Invalid Number Transfer"

--- a/definitions/verify.yml
+++ b/definitions/verify.yml
@@ -3,7 +3,7 @@ servers:
   - url: "https://api.nexmo.com/verify"
 info:
   title: Verify API
-  version: 1.1.7
+  version: 1.1.8
   description: >-
     The Verify API helps you to implement 2FA (two-factor authentication) in your applications.
     This is useful for:
@@ -15,18 +15,18 @@ info:
 
     * Ensuring that you can reach your users at any time because you have their correct phone number
 
-    More information is available at <https://developer.nexmo.com/verify>
+    More information is available at <https://developer.vonage.com/verify>
   contact:
     name: Vonage DevRel
     email: devrel@vonage.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
   termsOfService: "https://www.nexmo.com/terms-of-use"
   license:
     name: The MIT License (MIT)
     url: "https://opensource.org/licenses/MIT"
 externalDocs:
   description: "More information on the Verify product on our Developer Portal"
-  url: "https://developer.nexmo.com/verify"
+  url: "https://developer.vonage.com/verify"
 paths:
   "/{format}":
     post:
@@ -599,7 +599,7 @@ components:
           example: Acme Inc
         sender_id:
           description: >-
-            An 11-character alphanumeric string that represents the [identity of the sender](https://developer.nexmo.com/messaging/sms/guides/custom-sender-id)
+            An 11-character alphanumeric string that represents the [identity of the sender](https://developer.vonage.com/messaging/sms/guides/custom-sender-id)
             of the verification request. Depending on the destination of the phone number you are sending the verification SMS to,
             restrictions might apply.
           type: string
@@ -620,7 +620,7 @@ components:
             the locale that matches the `number`. For example, the text message
             or TTS message for a `33*` number is sent in French. Use this
             parameter to explicitly control the language used for the Verify
-            request. A list of languages is available: <https://developer.nexmo.com/verify/guides/verify-languages>
+            request. A list of languages is available: <https://developer.vonage.com/verify/guides/verify-languages>
           example: en-us
           type: string
           default: en-us
@@ -671,7 +671,7 @@ components:
             `pin_expiry` must be an integer multiple of `next_event_wait`
             otherwise `pin_expiry` is defaulted to equal next_event_wait. See
             [changing the event
-            timings](https://developer.nexmo.com/verify/guides/changing-default-timings).
+            timings](https://developer.vonage.com/verify/guides/changing-default-timings).
           type: integer
           minimum: 60
           maximum: 3600
@@ -692,7 +692,7 @@ components:
             actions to use in order to convey the PIN to your user. For example,
             an id of 1 identifies the workflow SMS - TTS - TTS. For a list of
             all workflows and their associated ids, please visit the [developer
-            portal](https://developer.nexmo.com/verify/guides/workflows-and-events).
+            portal](https://developer.vonage.com/verify/guides/workflows-and-events).
           type: integer
           default: 1
           enum:
@@ -1216,7 +1216,7 @@ components:
             `pin_expiry` must be an integer multiple of `next_event_wait`
             otherwise `pin_expiry` is defaulted to equal next_event_wait. See
             [changing the event
-            timings](https://developer.nexmo.com/verify/guides/changing-default-timings).
+            timings](https://developer.vonage.com/verify/guides/changing-default-timings).
           type: integer
           minimum: 60
           maximum: 3600
@@ -1237,7 +1237,7 @@ components:
             actions to use in order to convey the PIN to your user. For example,
             an id of 1 identifies the workflow SMS - TTS - TTS. For a list of
             all workflows and their associated ids, please visit the [developer
-            portal](https://developer.nexmo.com/verify/guides/workflows-and-events).
+            portal](https://developer.vonage.com/verify/guides/workflows-and-events).
           type: integer
           default: 1
           enum:

--- a/definitions/voice.v2.yml
+++ b/definitions/voice.v2.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.0
 info:
-  version: 2.2.2
+  version: 2.2.3
   title: Voice API BETA
   description: |
     This is the *beta* version of the Voice API. Calls created with v2 must be managed
@@ -14,7 +14,7 @@ info:
   contact:
     name: Vonage DevRel
     email: devrel@vonage.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
 servers:
   - url: https://api.nexmo.com/v2/calls
 paths:

--- a/definitions/voice.yml
+++ b/definitions/voice.yml
@@ -1,16 +1,16 @@
 ---
 openapi: 3.0.0
 info:
-  version: 1.3.7
+  version: 1.3.8
   title: Voice API
   description:
     The Voice API lets you create outbound calls, control in-progress calls
     and get information about historical calls. More information about the Voice API
-    can be found at <https://developer.nexmo.com/voice/voice-api/overview>.
+    can be found at <https://developer.vonage.com/voice/voice-api/overview>.
   contact:
     name: Vonage DevRel
     email: devrel@vonage.com
-    url: "https://developer.nexmo.com/"
+    url: "https://developer.vonage.com/"
 servers:
   - url: https://api.nexmo.com/v1/calls
 paths:
@@ -420,7 +420,7 @@ components:
                   text: Hello World
               items:
                 type: object
-              description: Refer to the [NCCO Guide](https://developer.nexmo.com/voice/voice-api/ncco-reference) for a description of possible NCCO parameters.
+              description: Refer to the [NCCO Guide](https://developer.vonage.com/voice/voice-api/ncco-reference) for a description of possible NCCO parameters.
               x-nexmo-developer-collection-description-shown: true
 
     UpdateCallRequestHangup:
@@ -803,7 +803,7 @@ components:
       type: string
       title: The State of the call
       example: started
-      description: The status of the call. [See possible values](https://developer.nexmo.com/voice/voice-api/guides/call-flow#event-objects)
+      description: The status of the call. [See possible values](https://developer.vonage.com/voice/voice-api/guides/call-flow#event-objects)
 
     EndpointApp:
       type: object
@@ -834,7 +834,7 @@ components:
         number:
           "$ref": "#/components/schemas/AddressE164"
         dtmfAnswer:
-          description: Provide [DTMF digits](https://developer.nexmo.com/voice/voice-api/guides/dtmf) to send when the call is answered
+          description: Provide [DTMF digits](https://developer.vonage.com/voice/voice-api/guides/dtmf) to send when the call is answered
           type: string
           example: p*123#
     EndpointPhoneFrom:

--- a/definitions/whatsapp-provisioning.yml
+++ b/definitions/whatsapp-provisioning.yml
@@ -1,13 +1,13 @@
 openapi: "3.0.3"
 info:
-  version: 0.1.4
+  version: 0.1.5
   title: WhatsApp Provisioning  API
   description: | 
     The WhatsApp Manager API enables customers to deploy a WhatsApp cluster, perform One Time Password (OTP) verification, and update profile information 
   contact:
     name: Nexmo DevRel
     email: devrel@nexmo.com
-    url: 'https://developer.nexmo.com/'
+    url: 'https://developer.vonage.com/'
   x-label: Beta
 servers:
   - url: https://api.nexmo.com/v0.1/whatsapp-manager
@@ -428,7 +428,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/whatsapp-provisioning#throttled
+          example: https://developer.vonage.com/api-errors/whatsapp-provisioning#throttled
         title:
           type: string
           description: Generic error message
@@ -452,7 +452,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/whatsapp-provisioning#conflict-resend-otp
+          example: https://developer.vonage.com/api-errors/whatsapp-provisioning#conflict-resend-otp
         title:
           type: string
           description: Generic error message
@@ -476,7 +476,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/whatsapp-provisioning#verification-failed
+          example: https://developer.vonage.com/api-errors/whatsapp-provisioning#verification-failed
         title:
           type: string
           description: Generic error message
@@ -514,7 +514,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/whatsapp-provisioning#unprocessable
+          example: https://developer.vonage.com/api-errors/whatsapp-provisioning#unprocessable
         title:
           type: string
           description: Generic error message
@@ -551,7 +551,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/whatsapp-provisioning#unprocessable-profile-update
+          example: https://developer.vonage.com/api-errors/whatsapp-provisioning#unprocessable-profile-update
         title:
           type: string
           description: Generic error message
@@ -588,7 +588,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/whatsapp-provisioning#conflict-deployment-state
+          example: https://developer.vonage.com/api-errors/whatsapp-provisioning#conflict-deployment-state
         title:
           type: string
           description: Generic error message
@@ -612,7 +612,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors#not-found
+          example: https://developer.vonage.com/api-errors#not-found
         title:
           type: string
           description: Generic error message
@@ -636,7 +636,7 @@ components:
         type:
           type: string
           description: Machine readable error type
-          example: https://developer.nexmo.com/api-errors#unauthorized
+          example: https://developer.vonage.com/api-errors#unauthorized
         title:
           type: string
           description: Error title
@@ -661,7 +661,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/whatsapp-provisioning#number-in-use
+          example: https://developer.vonage.com/api-errors/whatsapp-provisioning#number-in-use
         title:
           type: string
           description: Generic error message
@@ -686,7 +686,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors#forbidden
+          example: https://developer.vonage.com/api-errors#forbidden
         title:
           type: string
           description: Generic error message
@@ -711,7 +711,7 @@ components:
         type:
           type: string
           description: Link to error / remediation options
-          example: https://developer.nexmo.com/api-errors/whatsapp-provisioning#invalid-json
+          example: https://developer.vonage.com/api-errors/whatsapp-provisioning#invalid-json
         title:
           type: string
           description: Generic error message


### PR DESCRIPTION
# Description

<!--

The following will be used in our release notes and public changelog. Communicate well!

Example:

# New 

* Added new `/foobar/sync` endpoint to toggle widget status
* The `GET /v1/calls` endpoint now supports a `to` query parameter to filter calls to a single number

# Fixes

* Add HTTP 401 and 403 error code documentation to the `/v1/calls` endpoint
-->

# Checklist

- [ ] version number incremented (in the `info` section of the spec)
