### PR TITLE
added rate limit and bumped the version

### DIFF
--- a/definitions/reports.yml
+++ b/definitions/reports.yml
@@ -1,6 +1,6 @@
 openapi: '3.0.0'
 info:
-  version: 2.2.0
+  version: 2.2.1
   title: Reports API
   description: |
     The [Reports API](/reports/overview) enables you to request a report of activity for your Vonage account.
@@ -2357,3 +2357,6 @@ x-errors:
     link:
       text: View API reference
       url: /api/reports#cancel-report
+   rate-limit:
+    description: The request was rate limited.
+    resolution: The Reports API supports 5 requests per second. Slow down your request rate.

--- a/definitions/reports.yml
+++ b/definitions/reports.yml
@@ -2357,6 +2357,6 @@ x-errors:
     link:
       text: View API reference
       url: /api/reports#cancel-report
-   rate-limit:
+  rate-limit:
     description: The request was rate limited.
     resolution: The Reports API supports 5 requests per second. Slow down your request rate.


### PR DESCRIPTION
moving the comments over:
@niati I would suggest creating an entry here: https://developer.nexmo.com/api-errors and direct users there as part of the API response. See how redact does it: https://developer.nexmo.com/api/redact

# Description

<!--

The following will be used in our release notes and public changelog. Communicate well!

Example:

# New 

* Added new `/foobar/sync` endpoint to toggle widget status
* The `GET /v1/calls` endpoint now supports a `to` query parameter to filter calls to a single number

# Fixes

* Add HTTP 401 and 403 error code documentation to the `/v1/calls` endpoint
-->

# Checklist

- [ ] version number incremented (in the `info` section of the spec)
