### PR TITLE
OTT-4452: Remove WA template namespace

### DIFF
--- a/definitions/messages-olympus.v0.yml
+++ b/definitions/messages-olympus.v0.yml
@@ -822,8 +822,7 @@ components:
       type: array
       description: The parameters are an array. The first value being {{1}} in the template.
       example:
-        - Daisy
-        - '12345'
+        - '5'
       items:
         type: string
     imageMessageViberContent:
@@ -994,8 +993,8 @@ components:
           properties:
             name:
               type: string
-              description: The name of the template. For WhatsApp use your WhatsApp namespace (available via Facebook Business Manager), followed by a colon `:` and the name of the template to use.
-              example: example_namespace':'verify
+              description: The name of the template to use
+              example: sample_shipping_confirmation
             parameters:
               $ref: "#/components/schemas/templateParameters"
     templateMessageWhatsApp:
@@ -1017,7 +1016,7 @@ components:
                 - locale
               properties:
                 locale:
-                  example: "en-GB"
+                  example: "en_US"
                   type: string
                   description: The [BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) language of the template. Vonage will translate the BCP 47 format to the [WhatsApp equivalent](https://developers.facebook.com/docs/whatsapp/message-templates/creation#translations). For examples `en-GB` will be auto-translate to en_GB.
                 policy:

--- a/definitions/messages-olympus.yml
+++ b/definitions/messages-olympus.yml
@@ -567,8 +567,6 @@ components:
       type: array
       description: The parameters are an array of strings, with the first string being used for {{1}} in the template, with the second being {{2}} etc. Only required if the template specified by `name` contains parameters.
       example:
-        - Verification
-        - '2526'
         - '5'
       items:
         type: string
@@ -735,8 +733,8 @@ components:
               properties:
                 name:
                   type: string
-                  example: 9b6b4fcb_da19_4a26_8fe8_78074a91b584:verify
-                  description: 'The name of the template. For WhatsApp use your WhatsApp namespace (available via Facebook Business Manager), followed by a colon : and the name of the template to use.'
+                  example: sample_shipping_confirmation
+                  description: 'The name of the template to use'
                 parameters:
                   $ref: "#/components/schemas/TemplateParameters"
     Custom:


### PR DESCRIPTION
it's not mandatory anymore.
Also changed the example values to use a pre-populated WA template

# Description

# Fixes

* Removed WhatsApp template namespace since it's not required anymore
* Improved the WhatsApp template example to use a template pre-populated in all embedded sign-up accounts

<!--

The following will be used in our release notes and public changelog. Communicate well!

Example:

# New 

* Added new `/foobar/sync` endpoint to toggle widget status
* The `GET /v1/calls` endpoint now supports a `to` query parameter to filter calls to a single number

# Fixes

* Add HTTP 401 and 403 error code documentation to the `/v1/calls` endpoint
-->

# Checklist

- [ ] version number incremented (in the `info` section of the spec)
