### PR TITLE
[SMS-5619]:Conversion API Improve api-specification

### DIFF
--- a/definitions/conversion.yml
+++ b/definitions/conversion.yml
@@ -58,18 +58,80 @@ paths:
       parameters:
         - $ref: "#/components/parameters/message-id"
         - $ref: "#/components/parameters/delivered"
-        - $ref: "#/components/parameters/timestamp"
+
       responses:
         "200":
           description: OK
+
+          content:
+              text/plain:
+                schema:
+                  type: string
+                example: OK
+
         "401":
-          description: Wrong credentials
+          description: >-
+            Account permission is not setup to access API.
+
+          content:
+           text/plain:
+            schema:
+              type: string
+            example:
+                "401 Permission denied"
+
         "402":
-          description: Conversion has not been enabled for your account
-        "420":
-          description: Invalid parameters
-        "423":
-          description: Invalid parameters
+          description:  >-
+            - Wrong or expired JWT Tokens
+
+            - Request from an account is blocked
+
+            - Wrong credentials(api_key or api_secret)
+
+            - Conversions API call not enabled on account.
+
+          content:
+            text/plain:
+              schema:
+                type: string
+              example:
+                  402 Bad account credentials
+
+        "421":
+          description:  >-
+            Mandatory field "message-id" is unavailable in request body
+
+          content:
+            text/plain:
+              schema:
+                type: string
+              example:
+                  421 Missing message-id param
+
+        "422":
+          description:  >-
+            - Mandatory field 'delivered' is unavailable in request body"
+
+            - Field 'delivered' is other than 0|1|true|false
+          content:
+            text/plain:
+              schema:
+                type: string
+              example:
+                  "422 Missing or Invalid 'delivered' param"
+
+        "426":
+          description:  >-
+            - Mandatory field 'messageId' length is lesser than 16 or greater than 50
+          content:
+            text/plain:
+              schema:
+                type: string
+              example:
+                  "426 Invalid 'messageId' param"
+
+      requestBody:
+          $ref: "#/components/requestBodies/Ok"
   /voice:
     post:
       operationId: voiceConversion
@@ -84,18 +146,81 @@ paths:
       parameters:
         - $ref: "#/components/parameters/message-id"
         - $ref: "#/components/parameters/delivered"
-        - $ref: "#/components/parameters/timestamp"
+
       responses:
+
         "200":
           description: OK
+
+          content:
+              text/plain:
+                schema:
+                  type: string
+                example: OK
+
         "401":
-          description: Wrong credentials
+          description: >-
+            Account permission is not setup to access API.
+
+          content:
+           text/plain:
+            schema:
+              type: string
+            example:
+                "401 Permission denied"
+
         "402":
-          description: Conversion has not been enabled for your account
-        "420":
-          description: Invalid parameters
-        "423":
-          description: Invalid parameters
+          description:  >-
+            - Wrong or expired JWT Tokens
+
+            - Request from an account is blocked
+
+            - Wrong credentials(api_key or api_secret)
+
+            - Conversions API call not enabled on account.
+
+          content:
+            text/plain:
+              schema:
+                type: string
+              example:
+                  402 Bad account credentials
+
+        "421":
+          description:  >-
+            Mandatory field "message-id" is unavailable in request body
+
+          content:
+            text/plain:
+              schema:
+                type: string
+              example:
+                  421 Missing message-id param
+
+        "422":
+          description:  >-
+            - Mandatory field 'delivered' is unavailable in request body"
+
+            - Field 'delivered' is other than 0|1|true|false
+          content:
+            text/plain:
+              schema:
+                type: string
+              example:
+                  "422 Missing or Invalid 'delivered' param"
+
+        "426":
+          description:  >-
+            - Mandatory field 'messageId' length is lesser than 16 or greater than 50
+          content:
+            text/plain:
+              schema:
+                type: string
+              example:
+                  "426 Invalid 'messageId' param"
+
+      requestBody:
+          $ref: "#/components/requestBodies/Ok"
 components:
   parameters:
     message-id:
@@ -126,21 +251,6 @@ components:
           - 0
           - 1
       example: true
-    timestamp:
-      name: timestamp
-      required: true
-      in: query
-      description: >-
-        When the user completed your call-to-action (e.g. visited your website,
-        installed your app) in
-        [UTC±00:00](https://en.wikipedia.org/wiki/UTC%C2%B100:00) format:
-        _yyyy-MM-dd HH:mm:ss_.
-
-        If you do not set this parameter, Nexmo uses the time it receives this
-        request.
-      schema:
-        type: string
-      example: "2020-01-01 12:00:00"
   securitySchemes:
     apiKey:
       type: apiKey
@@ -163,3 +273,20 @@ components:
       description: >-
         The hash of the request parameters in alphabetical order, a timestamp
         and the signature secret. For example: `sig=SIGNATURE`
+
+  requestBodies:
+      Ok:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                api_key:
+                  $ref: "#/components/securitySchemes/apiKey"
+                api_secret:
+                  $ref: "#/components/securitySchemes/apiSecret"
+                message-id:
+                  $ref: "#/components/parameters/message-id"
+                delivered:
+                  $ref: "#/components/parameters/delivered"

--- a/definitions/conversion.yml
+++ b/definitions/conversion.yml
@@ -222,35 +222,29 @@ paths:
       requestBody:
           $ref: "#/components/requestBodies/Ok"
 components:
-  parameters:
+  schemas:
     message-id:
-      name: message-id
-      required: true
-      in: query
+      type: string
+      example: 0A000000010CA46C
       description: >-
         The ID you receive in the response to a request. * From the Verify API -
         use the `event_id` in the response to Verify Check. * From the SMS API -
         use the `message-id` * From the Text-To-Speech API - use the `call-id` *
         From the Text-To-Speech-Prompt API - use the `call-id`
-      schema:
-        type: string
-      example: 00A0B0C0
+
     delivered:
-      name: delivered
-      required: true
-      in: query
+      type: string
+      example: true
       description: >-
         Set to _true_ if your user replied to the message you sent. Otherwise,
         set to _false_.
 
         **Note**: for curl, use 0 and 1.
-      schema:
-        enum:
-          - true
-          - false
-          - 0
-          - 1
-      example: true
+      enum:
+        - true
+        - false
+        - 0
+        - 1
   securitySchemes:
     apiKey:
       type: apiKey

--- a/definitions/conversion.yml
+++ b/definitions/conversion.yml
@@ -56,8 +56,8 @@ paths:
       tags:
         - SMS Conversion
       parameters:
-        - $ref: "#/components/parameters/message-id"
-        - $ref: "#/components/parameters/delivered"
+        - $ref: "#/components/schemas/message-id"
+        - $ref: "#/components/schemas/delivered"
 
       responses:
         "200":
@@ -247,17 +247,20 @@ components:
         - 1
   securitySchemes:
     api_key:
-      type: apiKey
+      type: http
+      example: conv0001
       description: >-
         You can find your API key in your [account
         overview](https://dashboard.nexmo.com/account-overview)
     api_secret:
-      type: apiKey
+      type: http
+      example: conv0001
       description: >-
         You can find your API secret in your [account
         overview](https://dashboard.nexmo.com/account-overview)
     sig:
-      type: apiKey
+      type: http
+      example: conv0001
       description: >-
         The hash of the request parameters in alphabetical order, a timestamp
         and the signature secret. For example: `sig=SIGNATURE`
@@ -271,9 +274,9 @@ components:
               type: object
               properties:
                 api_key:
-                  $ref: "#/components/securitySchemes/apiKey"
+                  $ref: "#/components/securitySchemes/api_key"
                 api_secret:
-                  $ref: "#/components/securitySchemes/apiSecret"
+                  $ref: "#/components/securitySchemes/api_secret"
                 message-id:
                   $ref: "#/components/schemas/message-id"
                 delivered:

--- a/definitions/conversion.yml
+++ b/definitions/conversion.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Nexmo Conversion API
-  version: 1.0.1
+  version: 1.0.2
   description: >-
     The Conversion API allows you to tell Nexmo about the reliability of your
     2FA communications. Sending conversion data back to us means that Nexmo can

--- a/definitions/conversion.yml
+++ b/definitions/conversion.yml
@@ -246,31 +246,25 @@ components:
         - 0
         - 1
   securitySchemes:
-    apiKey:
+    api_key:
       type: apiKey
-      name: api_key
-      in: query
       description: >-
         You can find your API key in your [account
         overview](https://dashboard.nexmo.com/account-overview)
-    apiSecret:
+    api_secret:
       type: apiKey
-      name: api_secret
-      in: query
       description: >-
         You can find your API secret in your [account
         overview](https://dashboard.nexmo.com/account-overview)
-    apiSig:
+    sig:
       type: apiKey
-      name: sig
-      in: query
       description: >-
         The hash of the request parameters in alphabetical order, a timestamp
         and the signature secret. For example: `sig=SIGNATURE`
 
   requestBodies:
       Ok:
-        required: true
+        description: Conversion Request Payload Object
         content:
           application/json:
             schema:
@@ -281,6 +275,11 @@ components:
                 api_secret:
                   $ref: "#/components/securitySchemes/apiSecret"
                 message-id:
-                  $ref: "#/components/parameters/message-id"
+                  $ref: "#/components/schemas/message-id"
                 delivered:
-                  $ref: "#/components/parameters/delivered"
+                  $ref: "#/components/schemas/delivered"
+              required:
+                - api_key
+                - api_secret
+                - message-id
+                - delivered


### PR DESCRIPTION
# Description

<!--

The following will be used in our release notes and public changelog. Communicate well!

Example:

# New 

* Added new `/foobar/sync` endpoint to toggle widget status
* The `GET /v1/calls` endpoint now supports a `to` query parameter to filter calls to a single number

# Fixes

* Add HTTP 401 and 403 error code documentation to the `/v1/calls` endpoint
-->

# Checklist

- [x] version number incremented (in the `info` section of the spec)
