### PR TITLE
Add total_items to get rooms request

### DIFF
--- a/definitions/meetings.yml
+++ b/definitions/meetings.yml
@@ -24,6 +24,10 @@ paths:
                     type: integer
                     example: 10
                     description: The number of results returned on this page.
+                  total_items:
+                    type: integer
+                    example: 30
+                    description: The overall number of available rooms.
                   _embedded:
                     type: object
                     properties:

--- a/definitions/meetings.yml
+++ b/definitions/meetings.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Vonage Meetings Public API
-  version: 0.1.4
+  version: 0.1.5
   x-label: Beta
 servers:
   - url: https://api-eu.vonage.com/beta/meetings


### PR DESCRIPTION
# Description

<!--

The following will be used in our release notes and public changelog. Communicate well!

Example:

# New 

* Added new `/foobar/sync` endpoint to toggle widget status
* The `GET /v1/calls` endpoint now supports a `to` query parameter to filter calls to a single number

# Fixes

* Add HTTP 401 and 403 error code documentation to the `/v1/calls` endpoint
-->

# Checklist

- [ ] version number incremented (in the `info` section of the spec)
